### PR TITLE
Use AnonymizePath

### DIFF
--- a/TimVer/App.xaml.cs
+++ b/TimVer/App.xaml.cs
@@ -130,7 +130,7 @@ public partial class App : Application
                         TestLanguageStrings = testDict.Count;
                         TestLanguageFile = testDict.Source.OriginalString;
                         string str = (TestLanguageStrings == 1) ? "string" : "strings";
-                        _log.Debug($"{TestLanguageStrings} {str} loaded from {PathHelpers.GetCondensedPath(TestLanguageFile, 2, 2)}");
+                        _log.Debug($"{TestLanguageStrings} {str} loaded from {PathHelpers.AnonymizePath(TestLanguageFile)}");
                     }
                 }
                 catch (Exception ex)

--- a/TimVer/Configuration/ConfigHelpers.cs
+++ b/TimVer/Configuration/ConfigHelpers.cs
@@ -104,7 +104,7 @@ public static class ConfigHelpers
 
             if (saveFile.ShowDialog() == true)
             {
-                _log.Debug($"Exporting settings file to {PathHelpers.GetCondensedPath(saveFile.FileName, 2, 2)}.");
+                _log.Debug($"Exporting settings file to {PathHelpers.AnonymizePath(saveFile.FileName)}.");
                 string json = JsonSerializer.Serialize(UserSettings.Setting, _options);
                 File.WriteAllText(saveFile.FileName, json);
             }
@@ -138,7 +138,7 @@ public static class ConfigHelpers
 
             if (importFile.ShowDialog() == true)
             {
-                _log.Debug($"Importing settings file from {PathHelpers.GetCondensedPath(importFile.FileName, 2, 2)}.");
+                _log.Debug($"Importing settings file from {PathHelpers.AnonymizePath(importFile.FileName)}.");
                 ConfigManager<UserSettings>.Setting = JsonSerializer.Deserialize<UserSettings>(File.ReadAllText(importFile.FileName))!;
                 SaveSettings();
 

--- a/TimVer/Helpers/MainWindowHelpers.cs
+++ b/TimVer/Helpers/MainWindowHelpers.cs
@@ -166,7 +166,7 @@ internal static class MainWindowHelpers
         // Log the version, build date and commit id
         _log.Info($"{AppInfo.AppName} ({AppInfo.AppProduct}) {BuildInfo.VersionString} {GetStringResource("MsgText_ApplicationStarting")}");
         _log.Info($"{AppInfo.AppName} {AppInfo.AppCopyright}");
-        _log.Debug($"{AppInfo.AppName} was started from {PathHelpers.GetCondensedPath(AppInfo.AppPath, 2, 2)}");
+        _log.Debug($"{AppInfo.AppName} was started from {PathHelpers.AnonymizePath(AppInfo.AppPath)}");
         _log.Debug($"{AppInfo.AppName} Build date: {BuildInfo.BuildDateStringUtc}");
         _log.Debug($"{AppInfo.AppName} Commit ID: {BuildInfo.CommitIDString}");
         _log.Debug($"{AppInfo.AppName} Process ID: {AppInfo.AppProcessID}");

--- a/TimVer/Helpers/PathHelpers.cs
+++ b/TimVer/Helpers/PathHelpers.cs
@@ -51,4 +51,29 @@ internal static class PathHelpers
 
         return sb.ToString().TrimEnd(Path.DirectorySeparatorChar);
     }
+
+    /// <summary>
+    /// If a path to a file includes the user profile name replace it with %USERPROFILE%.
+    /// </summary>
+    /// <remarks>
+    /// Users may not want to have their user names visible in the log file, especially when sending that log with a bug
+    /// report. This method accomplishes that while still keeping the logged path usable.
+    /// </remarks>
+    /// <returns>
+    /// A string representing the path.
+    /// </returns>
+    public static string AnonymizePath(string path)
+    {
+        if (string.IsNullOrEmpty(path))
+        {
+            return string.Empty;
+        }
+
+        string userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (!path.StartsWith(userProfile, StringComparison.CurrentCultureIgnoreCase))
+        {
+            return path;
+        }
+        return path.Replace(userProfile, "%USERPROFILE%");
+    }
 }

--- a/TimVer/Helpers/TextFileViewer.cs
+++ b/TimVer/Helpers/TextFileViewer.cs
@@ -22,7 +22,7 @@ internal static class TextFileViewer
         string fname = string.Empty;
         try
         {
-            fname = PathHelpers.GetCondensedPath(textFile, 2, 2);
+            fname = PathHelpers.AnonymizePath(textFile);
 
             using Process p = new();
             p.StartInfo.FileName = textFile;


### PR DESCRIPTION
use AnonymizePath method to keep usernames from appearing in logs.

Users may not want to have their user names visible in the log file, especially when sending that log with a bug report. This method accomplishes that while still keeping the logged path usable.