### PR TITLE
Update processor cores label to "Cores / Threads"

### DIFF
--- a/TimVer/Helpers/ComputerSystemHelpers.cs
+++ b/TimVer/Helpers/ComputerSystemHelpers.cs
@@ -49,7 +49,7 @@ internal static class ComputerSystemHelpers
             {GetStringResource("HardwareInfo_Processor"), info.ProcessorName},
             {GetStringResource("HardwareInfo_ProcessorDescription"), info.ProcessorDescription},
             {GetStringResource("HardwareInfo_ProcessorArch"), info.ProcessorArchitecture},
-            {GetStringResource("HardwareInfo_Cores"), info.FormattedProcessorCores},
+            {GetStringResource("HardwareInfo_ProcessorCores"), info.FormattedProcessorCores},
             {GetStringResource("HardwareInfo_BiosManufacturer"), info.BiosManufacturer},
             {GetStringResource("HardwareInfo_BiosVersion"), info.FormattedBiosVersion},
             {GetStringResource("HardwareInfo_BiosMode"), info.UefiMode},
@@ -86,7 +86,7 @@ internal static class ComputerSystemHelpers
     }
     #endregion Get System information
 
-    #region Format processor string
+    #region Format processor cores string
     /// <summary>
     /// Combines processor cores and processor threads into a single string.
     /// </summary>
@@ -94,9 +94,9 @@ internal static class ComputerSystemHelpers
     {
         string hCores = GetStringResource("HardwareInfo_Cores");
         string hThreads = GetStringResource("HardwareInfo_Threads");
-        return $"{ProcessorHelpers.CimQueryProc("NumberOfCores")} {hCores} - {ProcessorHelpers.CimQueryProc("NumberOfLogicalProcessors")} {hThreads}";
+        return $"{ProcessorHelpers.CimQueryProc("NumberOfCores")} {hCores} / {ProcessorHelpers.CimQueryProc("NumberOfLogicalProcessors")} {hThreads}";
     }
-    #endregion Format processor string
+    #endregion Format processor cores string
 
     #region Format memory string
     /// <summary>

--- a/TimVer/Languages/Strings.en-US.xaml
+++ b/TimVer/Languages/Strings.en-US.xaml
@@ -170,7 +170,7 @@
     <sys:String x:Key="HardwareInfo_PhysicalMemory">Physical Memory</sys:String>
     <sys:String x:Key="HardwareInfo_Processor">Processor</sys:String>
     <sys:String x:Key="HardwareInfo_ProcessorArch">Processor Architecture</sys:String>
-    <sys:String x:Key="HardwareInfo_ProcessorCores">Processor Cores</sys:String>
+    <sys:String x:Key="HardwareInfo_ProcessorCores">Processor Cores / Threads</sys:String>
     <sys:String x:Key="HardwareInfo_ProcessorDescription">Processor Description</sys:String>
     <sys:String x:Key="HardwareInfo_SecureBoot">Secure Boot</sys:String>
     <sys:String x:Key="HardwareInfo_SecureBoot_Disabled">Disabled</sys:String>
@@ -514,4 +514,14 @@
     <!-- Begin changes on 2026/07/08 @ 19:30 UTC -->
     <!-- U | About_BuildDate - Changed 'Build' to 'Commit' -->
     <!-- End of changes on 2026/07/08 @ 19:30 UTC -->
+
+    <!-- Begin changes on 2026/07/13 @ 19:10 UTC -->
+    <!-- U | HardwareInfo_ProcessorCores - Added '/ Threads' to string -->
+    <!-- * | Note to Translators: If the term CPU is preferred over Processor in your language, please use CPU instead of Processor in the translation. -->
+    <!-- * |                      If changing Processor to CPU, please use the same term in these 4 keys for consistency. Thank you. -->
+    <!-- * |                      HardwareInfo_Processor             -->
+    <!-- * |                      HardwareInfo_ProcessorArch         -->
+    <!-- * |                      HardwareInfo_ProcessorCores        -->
+    <!-- * |                      HardwareInfo_ProcessorDescription  -->
+    <!-- End of changes on 2026/07/013 @ 19:10 UTC -->
 </ResourceDictionary>

--- a/TimVer/Languages/Strings.en-US.xaml
+++ b/TimVer/Languages/Strings.en-US.xaml
@@ -523,5 +523,5 @@
     <!-- * |                      HardwareInfo_ProcessorArch         -->
     <!-- * |                      HardwareInfo_ProcessorCores        -->
     <!-- * |                      HardwareInfo_ProcessorDescription  -->
-    <!-- End of changes on 2026/07/013 @ 19:10 UTC -->
+    <!-- End of changes on 2026/07/13 @ 19:10 UTC -->
 </ResourceDictionary>


### PR DESCRIPTION
Revised resource key to "Processor Cores / Threads" for clarity. Updated code to use the new key and changed formatting to use a slash separator. Added translator notes for consistent terminology across processor-related strings.

Closes #123 