### PR TITLE
Replace CommandLineParser with internal parser

### DIFF
--- a/TimVer/GlobalUsings.cs
+++ b/TimVer/GlobalUsings.cs
@@ -26,9 +26,6 @@ global using System.Windows.Media;
 global using System.Windows.Threading;
 global using System.Windows.Markup;
 
-global using CommandLineParser.Arguments;
-global using CommandLineParser.Exceptions;
-
 global using CommunityToolkit.Mvvm.ComponentModel;
 global using CommunityToolkit.Mvvm.Input;
 

--- a/TimVer/Helpers/CommandLineHelpers.cs
+++ b/TimVer/Helpers/CommandLineHelpers.cs
@@ -2,54 +2,36 @@
 
 namespace TimVer.Helpers;
 
-static class CommandLineHelpers
+internal static class CommandLineHelpers
 {
+    #region Properties
+    /// <summary>
+    /// Holds the parser error message when command-line parsing fails.
+    /// </summary>
+    public static string? CommandLineParserError { get; private set; }
+    #endregion Properties
+
     #region Process the command line
     /// <summary>
     /// Parse any command line options.
     /// </summary>
-    /// <returns><c>true</c> if "hide" option was specified.</returns>
-    public static bool ProcessCommandLine()
+    /// <returns>CommandLineArgs.Hide if "hide" was found.</returns>
+    public static CommandLineArgs ProcessCommandLine()
     {
-        CommandLineParser.CommandLineParser parser = new();
-        SwitchArgument hideArgument = new('h',
-                                                      "hide",
-                                                      "To hide or not to hide, that is the question.",
-                                                      false);
-        parser.Arguments.Add(hideArgument);
-        parser.AcceptSlash = true;
-        parser.IgnoreCase = true;
+        CommandLineParserError = null;
 
-        try
-        {
-            parser.ParseCommandLine(App.Args);
-        }
-        catch (UnknownArgumentException e)
-        {
-            CommandLineParserError = e.Message + e.StackTrace;
-        }
-        catch (Exception e)
-        {
-            CommandLineParserError = e.Message + e.StackTrace;
-        }
+        CommandLineOptions options = CommandLineOptionsParser.Parse(App.Args);
+        CommandLineParserError = options.ErrorMessage;
 
-        // Check options
-        if (hideArgument.Value)
-        {
-            _log.Debug("Command line argument \"hide\" specified.");
-            UpdateHistoryOnly = true;
-            return true;
-        }
-        return false;
+        return options.Hide ? CommandLineArgs.Hide : CommandLineArgs.None;
     }
     #endregion Process the command line
 
-    #region Properties
-    public static bool UpdateHistoryOnly { get; private set; }
-
-    /// <summary>
-    /// Holds exception message if there is a parser error.
-    /// </summary>
-    public static string? CommandLineParserError { get; private set; }
-    #endregion Properties
+    #region Enum for command line args
+    public enum CommandLineArgs
+    {
+        None = 0,
+        Hide = 1,
+    }
+    #endregion Enum for command line args
 }

--- a/TimVer/Helpers/CommandLineOptionsParser.cs
+++ b/TimVer/Helpers/CommandLineOptionsParser.cs
@@ -25,10 +25,7 @@ internal static class CommandLineOptionsParser
                 continue;
             }
 
-            if (IsSwitchArgument(argument))
-            {
-                return new CommandLineOptions(hide, $"Unknown argument: {rawArgument}");
-            }
+            return new CommandLineOptions(hide, $"Unknown argument: {rawArgument}");
         }
 
         return new CommandLineOptions(hide, null);
@@ -42,9 +39,4 @@ internal static class CommandLineOptionsParser
                normalized.Equals("hide", StringComparison.OrdinalIgnoreCase);
     }
 
-    private static bool IsSwitchArgument(string argument)
-    {
-        return argument.StartsWith('-') ||
-               argument.StartsWith('/');
-    }
 }

--- a/TimVer/Helpers/CommandLineOptionsParser.cs
+++ b/TimVer/Helpers/CommandLineOptionsParser.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Tim Kennedy. All Rights Reserved. Licensed under the MIT License.
+
+namespace TimVer.Helpers;
+
+internal sealed record CommandLineOptions(bool Hide, string? ErrorMessage);
+
+internal static class CommandLineOptionsParser
+{
+    internal static CommandLineOptions Parse(IEnumerable<string> arguments)
+    {
+        bool hide = false;
+
+        foreach (string rawArgument in arguments)
+        {
+            if (string.IsNullOrWhiteSpace(rawArgument))
+            {
+                continue;
+            }
+
+            string argument = rawArgument.Trim();
+
+            if (IsHideArgument(argument))
+            {
+                hide = true;
+                continue;
+            }
+
+            if (IsSwitchArgument(argument))
+            {
+                return new CommandLineOptions(hide, $"Unknown argument: {rawArgument}");
+            }
+        }
+
+        return new CommandLineOptions(hide, null);
+    }
+
+    private static bool IsHideArgument(string argument)
+    {
+        string normalized = argument.TrimStart('-', '/');
+
+        return normalized.Equals("h", StringComparison.OrdinalIgnoreCase) ||
+               normalized.Equals("hide", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsSwitchArgument(string argument)
+    {
+        return argument.StartsWith('-') ||
+               argument.StartsWith('/');
+    }
+}

--- a/TimVer/Helpers/MainWindowHelpers.cs
+++ b/TimVer/Helpers/MainWindowHelpers.cs
@@ -366,7 +366,7 @@ internal static class MainWindowHelpers
     /// Finds the Parent of the given item in the visual tree.
     /// </summary>
     /// <typeparam name="T">The type of the queried item.</typeparam>
-    /// <param name="child">parsedArgs:Name or Name of child.</param>
+    /// <param name="child">x:Name or Name of child.</param>
     /// <returns>The parent object.</returns>
     public static T FindParent<T>(DependencyObject child) where T : DependencyObject
     {

--- a/TimVer/Helpers/MainWindowHelpers.cs
+++ b/TimVer/Helpers/MainWindowHelpers.cs
@@ -7,6 +7,8 @@ namespace TimVer.Helpers;
 /// </summary>
 internal static class MainWindowHelpers
 {
+    private static bool UpdateHistoryOnly { get; set; }
+
     #region Startup
     internal static void TimVerStartUp()
     {
@@ -141,7 +143,7 @@ internal static class MainWindowHelpers
         // Shut down NLog
         LogManager.Shutdown();
 
-        if (!CommandLineHelpers.UpdateHistoryOnly)
+        if (UpdateHistoryOnly)
         {
             // Clear any remaining messages
             Snackbar snackbar = _mainWindow!.SnackBar1;
@@ -364,7 +366,7 @@ internal static class MainWindowHelpers
     /// Finds the Parent of the given item in the visual tree.
     /// </summary>
     /// <typeparam name="T">The type of the queried item.</typeparam>
-    /// <param name="child">x:Name or Name of child.</param>
+    /// <param name="child">parsedArgs:Name or Name of child.</param>
     /// <returns>The parent object.</returns>
     public static T FindParent<T>(DependencyObject child) where T : DependencyObject
     {
@@ -407,10 +409,13 @@ internal static class MainWindowHelpers
     /// </summary>
     private static void CheckCommandLine()
     {
-        if (CommandLineHelpers.ProcessCommandLine())
+        CommandLineHelpers.CommandLineArgs parsedArgs = CommandLineHelpers.ProcessCommandLine();
+        if (parsedArgs == CommandLineHelpers.CommandLineArgs.Hide)
         {
+            UpdateHistoryOnly = true;
             if (UserSettings.Setting!.KeepHistory)
             {
+                _log.Debug("Command line argument \"hide\" specified. Will update build history log if needed. ");
                 HistoryHelpers.WriteHistory();
             }
             else

--- a/TimVer/Helpers/MainWindowHelpers.cs
+++ b/TimVer/Helpers/MainWindowHelpers.cs
@@ -143,7 +143,7 @@ internal static class MainWindowHelpers
         // Shut down NLog
         LogManager.Shutdown();
 
-        if (UpdateHistoryOnly)
+        if (!UpdateHistoryOnly)
         {
             // Clear any remaining messages
             Snackbar snackbar = _mainWindow!.SnackBar1;

--- a/TimVer/Readme.txt
+++ b/TimVer/Readme.txt
@@ -166,8 +166,6 @@ TimVer uses the following packages:
 
     * Material Design in XAML Toolkit https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit
 
-    * CommandLineParser https://github.com/j-maly/CommandLineParser
-
     * Community Toolkit MVVM https://github.com/CommunityToolkit/dotnet
 
     * NLog https://nlog-project.org/

--- a/TimVer/TimVer.csproj
+++ b/TimVer/TimVer.csproj
@@ -42,7 +42,6 @@
 
   <!-- Packages -->
   <ItemGroup>
-    <PackageReference Include="CommandLineArgumentsParser" Version="3.0.23" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     <PackageReference Include="MaterialDesignThemes" Version="5.3.2" />
     <PackageReference Include="Microsoft.Management.Infrastructure" Version="3.0.0" />


### PR DESCRIPTION
Removed the CommandLineParser package and replaced it with an internal command-line parser implementation. Refactored CommandLineHelpers and MainWindowHelpers to use the new parser and updated error handling. Updated Readme.txt and project file to remove references to the external package.