### PR TITLE
Add customizable system light/dark themes support

### DIFF
--- a/TimVer/App.xaml
+++ b/TimVer/App.xaml
@@ -14,6 +14,7 @@
                 <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesign3.Defaults.xaml" />
                 <!--  Styles  -->
                 <ResourceDictionary Source="Styles/ButtonStyles.xaml" />
+                <ResourceDictionary Source="Styles/ComboBoxStyle.xaml" />
                 <ResourceDictionary Source="Styles/DataGridStyles.xaml" />
                 <ResourceDictionary Source="Styles/NavigationStyles.xaml" />
                 <ResourceDictionary Source="Styles/ScrollBarStyle.xaml" />

--- a/TimVer/Configuration/SettingChange.cs
+++ b/TimVer/Configuration/SettingChange.cs
@@ -77,7 +77,10 @@ public static class SettingChange
 
             case nameof(UserSettings.Setting.SystemLightTheme):
             case nameof(UserSettings.Setting.SystemDarkTheme):
-                MainWindowHelpers.SetBaseTheme(ThemeType.System);
+                if (UserSettings.Setting!.UITheme == ThemeType.System)
+                {
+                    MainWindowHelpers.SetBaseTheme(ThemeType.System);
+                }
                 break;
         }
     }

--- a/TimVer/Configuration/SettingChange.cs
+++ b/TimVer/Configuration/SettingChange.cs
@@ -74,6 +74,11 @@ public static class SettingChange
                 WindowsInfoViewModel.WindowsInfoList!.Clear();
                 WindowsInfoViewModel.LoadData();
                 break;
+
+            case nameof(UserSettings.Setting.SystemLightTheme):
+            case nameof(UserSettings.Setting.SystemDarkTheme):
+                MainWindowHelpers.SetBaseTheme(ThemeType.System);
+                break;
         }
     }
     #endregion User Setting change

--- a/TimVer/Configuration/UserSettings.cs
+++ b/TimVer/Configuration/UserSettings.cs
@@ -6,6 +6,8 @@ namespace TimVer.Configuration;
 public partial class UserSettings : ConfigManager<UserSettings>
 {
     #region Properties (some with default values)
+#pragma warning disable MVVMTK0042 // Prefer using [ObservableProperty] on partial properties
+    // Suppressing the MVVMTK0042 warning for this class until such time as it no longer requires Preview features.
     /// <summary>
     /// Check for updates automatically when About page is opened.
     /// </summary>
@@ -205,6 +207,18 @@ public partial class UserSettings : ConfigManager<UserSettings>
     private bool _startCentered = true;
 
     /// <summary>
+    /// Theme to use for light mode when ThemeType.System is selected.
+    /// </summary>
+    [ObservableProperty]
+    private ThemeType _systemLightTheme = ThemeType.Light;
+
+    /// <summary>
+    /// Theme to use for dark mode when ThemeType.System is selected.
+    /// </summary>
+    [ObservableProperty]
+    private ThemeType _systemDarkTheme = ThemeType.Darker;
+
+    /// <summary>
     /// Defined language to use in the UI.
     /// </summary>
     [ObservableProperty]
@@ -257,5 +271,6 @@ public partial class UserSettings : ConfigManager<UserSettings>
     /// </summary>
     [ObservableProperty]
     private double _windowWidth = 1000;
+#pragma warning restore MVVMTK0042 // Prefer using [ObservableProperty] on partial properties
     #endregion Properties (some with default values)
 }

--- a/TimVer/Converters/EnumToVisibilityConverter.cs
+++ b/TimVer/Converters/EnumToVisibilityConverter.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Tim Kennedy. All Rights Reserved. Licensed under the MIT License.
+
+namespace TimVer.Converters;
+
+/// <summary>
+/// Converts an enum value to Visibility based on whether it matches the parameter.
+/// Returns Visible if the value equals the parameter, otherwise Collapsed.
+/// </summary>
+public class EnumToVisibilityConverter : IValueConverter
+{
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value == null || parameter == null)
+        {
+            return Visibility.Collapsed;
+        }
+
+        return value.Equals(parameter) ? Visibility.Visible : Visibility.Collapsed;
+    }
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        return Binding.DoNothing;
+    }
+}

--- a/TimVer/Helpers/MainWindowHelpers.cs
+++ b/TimVer/Helpers/MainWindowHelpers.cs
@@ -205,7 +205,7 @@ internal static class MainWindowHelpers
     /// <summary>
     /// Sets the theme
     /// </summary>
-    /// <param name="mode">Light, Dark, Darker or System</param>
+    /// <param name="mode">A value in the ThemeType enum</param>
     internal static void SetBaseTheme(ThemeType mode)
     {
         //Retrieve the app's existing theme
@@ -214,7 +214,15 @@ internal static class MainWindowHelpers
 
         if (mode == ThemeType.System)
         {
-            mode = GetSystemTheme().Equals("light", StringComparison.OrdinalIgnoreCase) ? ThemeType.Light : ThemeType.Darker;
+            var systemTheme = GetSystemTheme();
+            mode = systemTheme.Equals("light", StringComparison.OrdinalIgnoreCase)
+                ? UserSettings.Setting!.SystemLightTheme
+                : UserSettings.Setting!.SystemDarkTheme;
+
+#if DEBUG
+            // For testing: log or expose the selected theme for verification
+            Debug.WriteLine($"System theme detected: {systemTheme}, applied: {mode}");
+#endif
         }
 
         switch (mode)

--- a/TimVer/Helpers/MainWindowHelpers.cs
+++ b/TimVer/Helpers/MainWindowHelpers.cs
@@ -219,6 +219,12 @@ internal static class MainWindowHelpers
                 ? UserSettings.Setting!.SystemLightTheme
                 : UserSettings.Setting!.SystemDarkTheme;
 
+            // Guard against invalid config values (e.g., System) so we always apply a concrete theme.
+            if (mode == ThemeType.System)
+            {
+                mode = systemTheme.Equals("light", StringComparison.OrdinalIgnoreCase) ? ThemeType.Light : ThemeType.Darker;
+            }
+
 #if DEBUG
             // For testing: log or expose the selected theme for verification
             Debug.WriteLine($"System theme detected: {systemTheme}, applied: {mode}");

--- a/TimVer/Languages/Strings.en-US.xaml
+++ b/TimVer/Languages/Strings.en-US.xaml
@@ -296,6 +296,7 @@
     <sys:String x:Key="SettingsItem_BuildHistoryToolTipLine2">Disabling this option will remove the History item from the navigation bar.</sys:String>
     <sys:String x:Key="SettingsItem_BuildHistoryToolTipLine3">See the ReadMe file for more information.</sys:String>
     <sys:String x:Key="SettingsItem_ChangingLanguageWarning">Changing Language will cause application to restart!</sys:String>
+    <sys:String x:Key="SettingsItem_DarkModeTheme">Dark Mode Theme</sys:String>
     <sys:String x:Key="SettingsItem_DateFormat">Grid Date Format</sys:String>
     <sys:String x:Key="SettingsItem_DisplayFont">Display Font</sys:String>
     <sys:String x:Key="SettingsItem_DisplayUser">Display registered user and organization on Windows Information page</sys:String>
@@ -310,6 +311,7 @@
     <sys:String x:Key="SettingsItem_InitialPage">Initial Page Displayed</sys:String>
     <sys:String x:Key="SettingsItem_KeepOnTop">Keep TimVer on top of other windows</sys:String>
     <sys:String x:Key="SettingsItem_Language">Language</sys:String>
+    <sys:String x:Key="SettingsItem_LightModeTheme">Light Mode Theme</sys:String>
     <sys:String x:Key="SettingsItem_LogicalDriveOptions">Logical Drive Options</sys:String>
     <sys:String x:Key="SettingsItem_PhysicalDriveCollection">Enable collection of Physical Drive information</sys:String>
     <sys:String x:Key="SettingsItem_PhysicalDriveCollectionTooltip">Collecting physical drive information can take a significant amount of time.</sys:String>
@@ -525,4 +527,9 @@
     <!-- * |                      HardwareInfo_ProcessorCores        -->
     <!-- * |                      HardwareInfo_ProcessorDescription  -->
     <!-- End of changes on 2026/07/13 @ 19:10 UTC -->
+
+    <!-- Begin changes on 2026/07/15 @ 15:30 UTC-->
+    <!-- A | SettingsItem_LightModeTheme  -->
+    <!-- A | SettingsItem_DarkModeTheme  -->
+    <!-- End of changes on 2026/07/15 @ 15:30 UTC-->
 </ResourceDictionary>

--- a/TimVer/Styles/ComboBoxStyle.xaml
+++ b/TimVer/Styles/ComboBoxStyle.xaml
@@ -1,0 +1,19 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!--#region Style for ComboBoxes on Settings pages-->
+    <Style TargetType="ComboBox"
+           x:Key="SettingsComboBox"
+           BasedOn="{StaticResource MaterialDesignComboBox}">
+        <Setter Property="Padding" Value="3,0,0,3" />
+        <Setter Property="Height" Value="34" />
+        <Setter Property="Width" Value="Auto" />
+        <Setter Property="MinWidth" Value="200" />
+        <Setter Property="HorizontalAlignment" Value="Left" />
+        <Setter Property="VerticalAlignment" Value="Bottom" />
+        <Setter Property="Margin" Value="0,3,0,0" />
+    </Style>
+    <!--#endregion-->
+
+
+</ResourceDictionary>

--- a/TimVer/ViewModels/SettingsViewModel.cs
+++ b/TimVer/ViewModels/SettingsViewModel.cs
@@ -11,6 +11,8 @@ internal sealed partial class SettingsViewModel : ObservableObject
     #region Properties
     public static ReadOnlyCollection<FontFamily>? FontList { get; private set; }
     public IEnumerable<ThemeType> ThemeTypes { get; private set; }
+
+    public IEnumerable<ThemeType> SystemThemeTypes { get; private set; }
     #endregion Properties
 
     #region Constructor
@@ -27,6 +29,9 @@ internal sealed partial class SettingsViewModel : ObservableObject
             ThemeType.DarkBlue,
             ThemeType.System,
         ];
+
+        // Used when ThemeType.System is selected. Will display all themes except System theme
+        SystemThemeTypes = [.. ThemeTypes.Where(t => t != ThemeType.System)];
     }
     #endregion Constructor
 

--- a/TimVer/Views/SettingsPage.xaml
+++ b/TimVer/Views/SettingsPage.xaml
@@ -17,6 +17,8 @@
     <!--#region Resources-->
     <UserControl.Resources>
         <convert:BooleanInverter x:Key="BoolInverter" />
+        <convert:EnumToVisibilityConverter x:Key="EnumToVisibility" />
+
     </UserControl.Resources>
     <!--#endregion-->
 
@@ -440,80 +442,101 @@
                         <Grid Grid.Row="0" Grid.Column="1">
                             <!--#region Row & Column definitions-->
                             <Grid.RowDefinitions>
-                                <RowDefinition Height="38" />
-                                <RowDefinition Height="38" />
-                                <RowDefinition Height="38" />
-                                <RowDefinition Height="38" />
-                                <RowDefinition Height="38" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
                             </Grid.RowDefinitions>
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="auto" MinWidth="100" />
                                 <ColumnDefinition Width="10" />
                                 <ColumnDefinition />
                             </Grid.ColumnDefinitions>
+                            <Grid.DataContext>
+                                <viewmodels:SettingsViewModel />
+                            </Grid.DataContext>
                             <!--#endregion-->
                             <Label Grid.Row="0" Grid.Column="0"
                                    VerticalAlignment="Center"
                                    Content="{DynamicResource SettingsItem_Theme}" />
                             <StackPanel Grid.Row="0" Grid.Column="2">
-                                <StackPanel.DataContext>
-                                    <viewmodels:SettingsViewModel />
-                                </StackPanel.DataContext>
-                                <ComboBox Width="Auto" MinWidth="200"
-                                          Margin="0,3,0,0" Padding="2,0,0,3"
-                                          HorizontalAlignment="Left"
-                                          ItemsSource="{Binding ThemeTypes}"
+                                <ComboBox ItemsSource="{Binding ThemeTypes}"
                                           SelectedItem="{Binding UITheme,
                                                                  Source={x:Static config:UserSettings.Setting}}"
-                                          Style="{StaticResource MaterialDesignComboBox}" />
+                                          Style="{StaticResource SettingsComboBox}" />
                             </StackPanel>
+
                             <Label Grid.Row="1" Grid.Column="0"
                                    VerticalAlignment="Center"
-                                   Content="{DynamicResource SettingsItem_UISize}" />
+                                   Content="{DynamicResource SettingsItem_LightModeTheme}"
+                                   Visibility="{Binding UITheme,
+                                                        Source={x:Static config:UserSettings.Setting},
+                                                        Converter={StaticResource EnumToVisibility},
+                                                        ConverterParameter={x:Static models:ThemeType.System}}" />
                             <ComboBox Grid.Row="1" Grid.Column="2"
-                                      Width="Auto" MinWidth="200"
-                                      Margin="0,3,0,0" Padding="2,0,0,3"
-                                      HorizontalAlignment="Left"
+                                      ItemsSource="{Binding SystemThemeTypes}"
+                                      SelectedItem="{Binding SystemLightTheme,
+                                                             Source={x:Static config:UserSettings.Setting}}"
+                                      Style="{StaticResource SettingsComboBox}"
+                                      Visibility="{Binding UITheme,
+                                                           Source={x:Static config:UserSettings.Setting},
+                                                           Converter={StaticResource EnumToVisibility},
+                                                           ConverterParameter={x:Static models:ThemeType.System}}" />
+
+                            <Label Grid.Row="2" Grid.Column="0"
+                                   VerticalAlignment="Center"
+                                   Content="{DynamicResource SettingsItem_DarkModeTheme}"
+                                   Visibility="{Binding UITheme,
+                                                        Source={x:Static config:UserSettings.Setting},
+                                                        Converter={StaticResource EnumToVisibility},
+                                                        ConverterParameter={x:Static models:ThemeType.System}}" />
+                            <ComboBox Grid.Row="2" Grid.Column="2"
+                                      ItemsSource="{Binding SystemThemeTypes}"
+                                      SelectedItem="{Binding SystemDarkTheme,
+                                                             Source={x:Static config:UserSettings.Setting}}"
+                                      Style="{StaticResource SettingsComboBox}"
+                                      Visibility="{Binding UITheme,
+                                                           Source={x:Static config:UserSettings.Setting},
+                                                           Converter={StaticResource EnumToVisibility},
+                                                           ConverterParameter={x:Static models:ThemeType.System}}" />
+                            <Label Grid.Row="3" Grid.Column="0"
+                                   VerticalAlignment="Center"
+                                   Content="{DynamicResource SettingsItem_UISize}" />
+                            <ComboBox Grid.Row="3" Grid.Column="2"
                                       ItemsSource="{Binding Source={convert:EnumBindingSource {x:Type models:MySize}}}"
                                       SelectedItem="{Binding UISize,
                                                              Source={x:Static config:UserSettings.Setting}}"
-                                      Style="{StaticResource MaterialDesignComboBox}" />
-                            <Label Grid.Row="2" Grid.Column="0"
+                                      Style="{StaticResource SettingsComboBox}" />
+                            <Label Grid.Row="4" Grid.Column="0"
                                    VerticalAlignment="Center"
                                    Content="{DynamicResource SettingsItem_AccentColor}" />
-                            <ComboBox Grid.Row="2" Grid.Column="2"
-                                      Width="Auto" MinWidth="200"
-                                      Margin="0,3,0,0" Padding="2,0,0,3"
-                                      HorizontalAlignment="Left"
+                            <ComboBox Grid.Row="4" Grid.Column="2"
                                       ItemsSource="{Binding Source={convert:EnumBindingSource {x:Type models:AccentColor}}}"
                                       MaxDropDownHeight="300"
                                       SelectedItem="{Binding PrimaryColor,
                                                              Source={x:Static config:UserSettings.Setting}}"
-                                      Style="{StaticResource MaterialDesignComboBox}" />
-                            <Label Grid.Row="3" Grid.Column="0"
+                                      Style="{StaticResource SettingsComboBox}" />
+                            <Label Grid.Row="5" Grid.Column="0"
                                    VerticalAlignment="Center"
                                    Content="{DynamicResource SettingsItem_DisplayFont}" />
-                            <ComboBox Grid.Row="3" Grid.Column="2"
-                                      Width="Auto" MinWidth="200"
-                                      Margin="0,3,0,0" Padding="3,0,0,3"
-                                      HorizontalAlignment="Left"
+                            <ComboBox Grid.Row="5" Grid.Column="2"
                                       d:DataContext="{d:DesignInstance Type=viewmodels:SettingsViewModel}"
                                       ItemsSource="{Binding FontList}"
                                       SelectedValue="{Binding SelectedFont,
                                                               Source={x:Static config:UserSettings.Setting}}"
                                       SelectedValuePath="Source"
-                                      Style="{StaticResource MaterialDesignComboBox}" />
-                            <Label Grid.Row="4" Grid.Column="0"
+                                      Style="{StaticResource SettingsComboBox}" />
+                            <Label Grid.Row="6" Grid.Column="0"
                                    VerticalAlignment="Center"
                                    Content="{DynamicResource SettingsItem_RowHeight}" />
-                            <ComboBox Grid.Row="4" Grid.Column="2"
-                                      Width="Auto" MinWidth="200"
-                                      Margin="0,3,0,0" Padding="2,0,0,3"
-                                      HorizontalAlignment="Left"
+                            <ComboBox Grid.Row="6" Grid.Column="2"
                                       ItemsSource="{Binding Source={convert:EnumBindingSource {x:Type models:Spacing}}}"
                                       SelectedItem="{Binding RowSpacing,
                                                              Source={x:Static config:UserSettings.Setting}}"
-                                      Style="{StaticResource MaterialDesignComboBox}" />
+                                      Style="{StaticResource SettingsComboBox}" />
                         </Grid>
                         <Grid Grid.Row="2" Grid.Column="1">
                             <Grid.RowDefinitions>


### PR DESCRIPTION
Introduce SystemLightTheme and SystemDarkTheme properties in UserSettings to let users select themes for system light/dark modes. Update theme selection logic and settings UI to show ComboBoxes for these options when "System" is selected. Add EnumToVisibilityConverter and a new ComboBox style for consistent UI. Update resource strings and expose filtered theme lists in SettingsViewModel.