### PR TITLE
Refactor UEFI detection, remove Vanara, update locales

### DIFF
--- a/TimVer/Helpers/UefiHelpers.cs
+++ b/TimVer/Helpers/UefiHelpers.cs
@@ -1,54 +1,101 @@
 ﻿// Copyright (c) Tim Kennedy. All Rights Reserved. Licensed under the MIT License.
-using static Vanara.PInvoke.Kernel32;
 
 namespace TimVer.Helpers;
+
 /// <summary>
 /// Class for UEFI related things.
 /// </summary>
-internal static class UefiHelpers
+internal static partial class UefiHelpers
 {
+    #region Get secure boot state
     /// <summary>
     /// Determines if UEFI secure boot is enabled.
     /// </summary>
-    /// <returns><c>true</c> if UEFI secure boot is enabled.</returns>
+    /// <returns>Localized string</returns>
     public static string UEFISecureBoot()
     {
         try
         {
             using RegistryKey? key = Registry.LocalMachine.OpenSubKey(@"SYSTEM\CurrentControlSet\Control\SecureBoot\State");
-            return (int?)key!.GetValue("UEFISecureBootEnabled") == 1 ?
-                GetStringResource("HardwareInfo_SecureBoot_Enabled") :
-                GetStringResource("HardwareInfo_SecureBoot_Disabled");
+            object? secureBootValue = key?.GetValue("UEFISecureBootEnabled");
+            if (secureBootValue is int secureBootEnabled)
+            {
+                return secureBootEnabled == 1 ?
+                    GetStringResource("HardwareInfo_SecureBoot_Enabled") :
+                    GetStringResource("HardwareInfo_SecureBoot_Disabled");
+            }
+
+            _log.Warn("UEFISecureBootEnabled registry value is not available.");
+            return GetStringResource("MsgText_NotAvailable");
         }
         catch (Exception ex)
         {
             _log.Error(ex, "Call to UEFISecureBoot has failed.");
-            return GetStringResource("ErrorGeneral");
+            return GetStringResource("MsgText_ErrorGeneral");
         }
     }
+    #endregion Get secure boot state
 
+    #region Get UEFI mode
     /// <summary>
-    /// Determines if computer is in EUFI mode.
+    /// Determines if computer is in UEFI mode.
     /// </summary>
-    /// <returns>"UEFI mode" if the computer is in UEFI mode. "BIOS mode"if the computer is in BIOS mode.</returns>
-    /// <remarks>https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-getfirmwareenvironmentvariablea</remarks>
+    /// <returns>
+    /// Localized string for "UEFI mode" if the computer is in UEFI mode. "BIOS mode"if the computer is in BIOS mode.
+    /// </returns>
+    /// <remarks>
+    /// https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-getfirmwaretype
+    /// </remarks>
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool GetFirmwareType(out FirmwareType firmwareType);
+
     public static string UEFIEnabled()
     {
         try
         {
-            const int ERROR_INVALID_FUNCTION = 1;
-            _ = GetFirmwareEnvironmentVariable("",
-                                               "{00000000-0000-0000-0000-000000000000}",
-                                               IntPtr.Zero,
-                                               0);
-            return GetLastError() != ERROR_INVALID_FUNCTION ?
-                GetStringResource("HardwareInfo_UEFI") :
-                GetStringResource("HardwareInfo_BIOS");
+            if (GetFirmwareType(out FirmwareType firmwareType))
+            {
+                switch (firmwareType)
+                {
+                    case FirmwareType.Bios:
+                        return GetStringResource("HardwareInfo_BIOS");
+                    case FirmwareType.Uefi:
+                        return GetStringResource("HardwareInfo_UEFI");
+                    case FirmwareType.Unknown:
+                    case FirmwareType.Max:
+                        return GetStringResource("MsgText_UefiUnknown");
+                }
+            }
+            else
+            {
+                _log.Error($"Error retrieving firmware type. Win32 Error: {Marshal.GetLastWin32Error()}");
+                return GetStringResource("MsgText_ErrorGeneral");
+            }
+        }
+        catch (EntryPointNotFoundException ex)
+        {
+            _log.Error(ex, "GetFirmwareType is not supported on this version of Windows.");
+            return GetStringResource("MsgText_ErrorGeneral");
         }
         catch (Exception ex)
         {
-            _log.Error(ex, "Call to UEFIEnabled has failed.");
-            return GetStringResource("ErrorGeneral");
+            _log.Error(ex, $"Unexpected error: {ex.Message}");
+            return GetStringResource("MsgText_ErrorGeneral");
         }
+
+        return string.Empty;
     }
 }
+    #endregion
+
+#region Enum for firmware types
+enum FirmwareType : uint
+{
+    Unknown = 0,
+    Bios = 1,
+    Uefi = 2,
+    Max = 3
+}
+#endregion Enum for firmware types

--- a/TimVer/Helpers/UefiHelpers.cs
+++ b/TimVer/Helpers/UefiHelpers.cs
@@ -41,7 +41,7 @@ internal static partial class UefiHelpers
     /// Determines if computer is in UEFI mode.
     /// </summary>
     /// <returns>
-    /// Localized string for "UEFI mode" if the computer is in UEFI mode. "BIOS mode"if the computer is in BIOS mode.
+    /// Localized string for "UEFI mode" if the computer is in UEFI mode. "BIOS mode" if the computer is in BIOS mode.
     /// </returns>
     /// <remarks>
     /// https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-getfirmwaretype

--- a/TimVer/Languages/Strings.en-US.xaml
+++ b/TimVer/Languages/Strings.en-US.xaml
@@ -532,6 +532,6 @@
     <!-- Begin changes on 2026/07/15 @ 23:30 UTC-->
     <!-- A | SettingsItem_LightModeTheme  -->
     <!-- A | SettingsItem_DarkModeTheme  -->
-    <!-- A | SettingsItem_MsgText_UefiUnknown  -->
+    <!-- A | MsgText_UefiUnknown  -->
     <!-- End of changes on 2026/07/15 @ 23:30 UTC-->
 </ResourceDictionary>

--- a/TimVer/Languages/Strings.en-US.xaml
+++ b/TimVer/Languages/Strings.en-US.xaml
@@ -220,6 +220,7 @@
     <sys:String x:Key="MsgText_SeeLogFile">See the log file for additional information.</sys:String>
     <sys:String x:Key="MsgText_Thousand">thousand</sys:String>
     <sys:String x:Key="MsgText_Translated">translated</sys:String>
+    <sys:String x:Key="MsgText_UefiUnknown">Unable to determine UEFI state</sys:String>
     <sys:String x:Key="MsgText_UIColorSet">Accent color set to {0}</sys:String>
     <sys:String x:Key="MsgText_UISizeSet">Size set to {0}</sys:String>
     <sys:String x:Key="MsgText_UIThemeSet">Theme set to {0}</sys:String>
@@ -528,8 +529,9 @@
     <!-- * |                      HardwareInfo_ProcessorDescription  -->
     <!-- End of changes on 2026/07/13 @ 19:10 UTC -->
 
-    <!-- Begin changes on 2026/07/15 @ 15:30 UTC-->
+    <!-- Begin changes on 2026/07/15 @ 23:30 UTC-->
     <!-- A | SettingsItem_LightModeTheme  -->
     <!-- A | SettingsItem_DarkModeTheme  -->
-    <!-- End of changes on 2026/07/15 @ 15:30 UTC-->
+    <!-- A | SettingsItem_MsgText_UefiUnknown  -->
+    <!-- End of changes on 2026/07/15 @ 23:30 UTC-->
 </ResourceDictionary>

--- a/TimVer/Languages/Strings.es-ES.xaml
+++ b/TimVer/Languages/Strings.es-ES.xaml
@@ -15,7 +15,7 @@
 
         Translation contributed by:  Timthreetwelve and Google Translate
 
-        Date last update:            2026/07/08
+        Date last update:            2026/07/15
 
         ======================================================================
 
@@ -191,6 +191,7 @@
     <sys:String x:Key="MsgText_AppUpdateNoneFound">No se encontraron versiones más recientes.</sys:String>
     <sys:String x:Key="MsgText_CopiedToClipboard">La página actual se copió en el portapapeles.</sys:String>
     <sys:String x:Key="MsgText_CopiedToClipboardItem">El elemento se copió en el portapapeles</sys:String>
+    <sys:String x:Key="MsgText_CopyToClipboardFail">Error al copiar al portapapeles</sys:String>
     <sys:String x:Key="MsgText_CopyToClipboardInvalid">Copiar al portapapeles no es válido en esta página</sys:String>
     <sys:String x:Key="MsgText_DriveInfoRefreshed">Información de la unidad de disco actualizada</sys:String>
     <sys:String x:Key="MsgText_ErrorCaption">ERROR</sys:String>
@@ -216,6 +217,7 @@
     <sys:String x:Key="MsgText_UIColorSet">Color de énfasis establecido en {0}</sys:String>
     <sys:String x:Key="MsgText_UISizeSet">Tamaño establecido en {0}</sys:String>
     <sys:String x:Key="MsgText_UIThemeSet">Tema establecido en {0}</sys:String>
+    <sys:String x:Key="MsgText_UefiUnknown">No se puede determinar el estado de UEFI</sys:String>
     <sys:String x:Key="MsgText_WindowTitleAdministrator">Administrador</sys:String>
     <sys:String x:Key="MsgText_ErrorExportingSettings">Error al exportar el archivo de configuración.</sys:String>
     <sys:String x:Key="MsgText_ErrorImportingSettings">Error al importar el archivo de configuración.</sys:String>
@@ -294,6 +296,7 @@
     <sys:String x:Key="SettingsItem_BuildHistoryToolTipLine2">Al desactivar esta opción se eliminará el elemento Historial de la barra de navegación.</sys:String>
     <sys:String x:Key="SettingsItem_BuildHistoryToolTipLine3">Consulte el archivo Léame para obtener más información.</sys:String>
     <sys:String x:Key="SettingsItem_ChangingLanguageWarning">¡Cambiar el idioma hará que la aplicación se reinicie!</sys:String>
+    <sys:String x:Key="SettingsItem_DarkModeTheme">Tema del modo oscuro</sys:String>
     <sys:String x:Key="SettingsItem_DateFormat">Formato de fecha de cuadrícula</sys:String>
     <sys:String x:Key="SettingsItem_DisplayFont">Fuente de visualización</sys:String>
     <sys:String x:Key="SettingsItem_DisplayUser">Mostrar el usuario registrado y la organización en la página de información de Windows</sys:String>
@@ -307,6 +310,7 @@
     <sys:String x:Key="SettingsItem_InitialPage">Página inicial mostrada</sys:String>
     <sys:String x:Key="SettingsItem_KeepOnTop">Mantenga TimVer encima de otras ventanas</sys:String>
     <sys:String x:Key="SettingsItem_Language">Idioma</sys:String>
+    <sys:String x:Key="SettingsItem_LightModeTheme">Tema del modo claro</sys:String>
     <sys:String x:Key="SettingsItem_LogicalDriveOptions">Opciones de unidad lógica</sys:String>
     <sys:String x:Key="SettingsItem_PhysicalDriveCollection">Habilitar la recopilación de información de la unidad física</sys:String>
     <sys:String x:Key="SettingsItem_PhysicalDriveCollectionTooltip">La recopilación de información del disco físico puede llevar una cantidad significativa de tiempo.</sys:String>

--- a/TimVer/Readme.txt
+++ b/TimVer/Readme.txt
@@ -176,8 +176,6 @@ TimVer uses the following packages:
 
     * OctoKit https://github.com/octokit/octokit.net
 
-    * Vanara https://github.com/dahall/vanara
-
     * GitKraken was used for everything Git related. https://www.gitkraken.com/
 
     * Inno Setup was used to create the installer. https://jrsoftware.org/isinfo.php

--- a/TimVer/TimVer.csproj
+++ b/TimVer/TimVer.csproj
@@ -13,6 +13,7 @@
     <Company>T_K</Company>
     <Product>TimVer</Product>
     <CsWinRTAotOptimizerEnabled>false</CsWinRTAotOptimizerEnabled>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <!-- Set version and prerelease string (if needed) -->
@@ -55,7 +56,6 @@
     <PackageReference Include="VersionInfoGenerator" Version="3.2.1" PrivateAssets="all"/>
     <PackageReference Include="NLog" Version="6.1.4" />
     <PackageReference Include="Octokit" Version="14.0.0" />
-    <PackageReference Include="Vanara.PInvoke.Kernel32" Version="5.0.5" />
   </ItemGroup>
 
   <!-- Build complete message -->


### PR DESCRIPTION
Refactored `UefiHelpers` to use native `GetFirmwareType` via source generator interop, replacing `Vanara.PInvoke.Kernel32` for UEFI/BIOS detection. Improved secure boot detection logic for null safety and error handling. Localized all user-facing strings and added `MsgText_UefiUnknown` to English and Spanish resources. Removed `Vanara.PInvoke.Kernel32` from the project and updated the Readme. Updated localization change log.