### PR TITLE
Show/hide Copy Page to Clipboard button based on current page

### DIFF
--- a/TimVer/Helpers/ClipboardHelper.cs
+++ b/TimVer/Helpers/ClipboardHelper.cs
@@ -227,7 +227,7 @@ internal static class ClipboardHelper
             default:
                 SnackbarMsg.ClearAndQueueMessage(GetStringResource("MsgText_CopyToClipboardInvalid"));
                 SystemSounds.Exclamation.Play();
-                break;
+                return;
         }
         if (await CopyTextToClipboardAsync(builder.ToString()))
         {

--- a/TimVer/MainWindow.xaml
+++ b/TimVer/MainWindow.xaml
@@ -25,6 +25,7 @@
     <!--#region Resources-->
     <Window.Resources>
         <convert:SelectedItemConverter x:Key="SelItemConv" />
+        <BooleanToVisibilityConverter x:Key="BoolToVisConv" />
     </Window.Resources>
     <!--#endregion-->
 
@@ -87,6 +88,7 @@
                     HorizontalAlignment="Center"
                     Command="{Binding CopyToClipboardCommand}"
                     IsDefault="False" IsTabStop="False"
+                    Visibility="{Binding ShowCopyButton, Converter={StaticResource BoolToVisConv}}"
                     Style="{StaticResource CopyToClipboardButton}"
                     ToolTip="{DynamicResource Button_CopyToClipboardToolTip}" />
 

--- a/TimVer/ViewModels/NavigationViewModel.cs
+++ b/TimVer/ViewModels/NavigationViewModel.cs
@@ -29,6 +29,9 @@ internal sealed partial class NavigationViewModel : ObservableObject
 
     [ObservableProperty]
     private static NavigationItem? _navItem;
+
+    [ObservableProperty]
+    private bool _showCopyButton = true;
 #pragma warning restore MVVMTK0042
     #endregion Properties
 
@@ -128,6 +131,12 @@ internal sealed partial class NavigationViewModel : ObservableObject
                 CurrentViewModel = null;
                 CurrentViewModel = Activator.CreateInstance((Type)item.ViewModelType);
                 NavItem = item;
+                ShowCopyButton = item.NavPage switch
+                {
+                    NavPage.Settings => false,
+                    NavPage.About => false,
+                    _ => true
+                };
             }
         }
     }


### PR DESCRIPTION
Added `BooleanToVisibilityConverter` to `MainWindow.xaml` and bound the Copy to Clipboard button's Visibility to a new `ShowCopyButton` property in `NavigationViewModel`. `ShowCopyButton` is now updated by navigation logic to hide the button on Settings and About pages and show it elsewhere.