### PR TITLE
Transition to x64 only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,7 +172,7 @@ publish/
 *.azurePubxml
 # Note: Comment the next line if you want to checkin your web deploy settings,
 # but database connection strings (with potential passwords) will be unencrypted
-*.pubxml
+#*.pubxml
 *.publishproj
 
 # Microsoft Azure Web App publish settings. Comment the next line if you want to
@@ -344,6 +344,7 @@ healthchecksdb
 
 # override .gitignore_global 
 !TimVer/BuildInfo.cs
+!**/*.pubxml
 
 # Error list
 TimVer.el.txt

--- a/TimVer.slnx
+++ b/TimVer.slnx
@@ -1,3 +1,8 @@
 <Solution>
-  <Project Path="TimVer/TimVer.csproj" />
+  <Configurations>
+    <Platform Name="x64" />
+  </Configurations>
+  <Project Path="TimVer/TimVer.csproj">
+    <Platform Project="x64" />
+  </Project>
 </Solution>

--- a/TimVer/Inno_Setup/TimVerEx.iss
+++ b/TimVer/Inno_Setup/TimVerEx.iss
@@ -157,8 +157,7 @@ var
   Text: String;
 begin
   case ExpandConstant('{#InstallType}') of
-    'x64x86': Text := FmtMessage( CustomMessage('NotSelfContained'), [ExpandConstant('{#MyAppName}'), ExpandConstant('{#MyAppVersion}')]); 
-    'SC_x86': Text := FmtMessage( CustomMessage('SelfContainedx86'), [ExpandConstant('{#MyAppName}'), ExpandConstant('{#MyAppVersion}')]); 
+    'FD_x64': Text := FmtMessage( CustomMessage('NotSelfContained64'), [ExpandConstant('{#MyAppName}'), ExpandConstant('{#MyAppVersion}')]); 
     'SC_x64': Text := FmtMessage( CustomMessage('SelfContainedx64'), [ExpandConstant('{#MyAppName}'), ExpandConstant('{#MyAppVersion}')]);
   else
       Text := WizardForm.WelcomeLabel2.Caption;

--- a/TimVer/Inno_Setup/TimVerLocalization.iss
+++ b/TimVer/Inno_Setup/TimVerLocalization.iss
@@ -3,59 +3,55 @@ DialogFontSize=9
 DialogFontName="Segoe UI"
 WelcomeFontSize=14
 WelcomeFontName="Verdana"
-
+;
+;
 [Languages]
 Name: "en"; MessagesFile: "compiler:Default.isl"
 Name: "ko"; MessagesFile: "compiler:Languages\Korean.isl"
 Name: "es"; MessagesFile: "compiler:Languages\Spanish.isl"
 Name: "it"; MessagesFile: "compiler:Languages\Italian.isl"
 Name: "nl"; MessagesFile: "compiler:Languages\Dutch.isl"
-Name: "sk"; MessagesFile: "compiler:Languages\Slovak.isl"
-
+;
+;
 [Messages]
 en.SetupWindowTitle = Setup - {#MyAppName} {#MyAppVersion}
 es.SetupWindowTitle = Instalar - {#MyAppName} {#MyAppVersion}
 it.SetupWindowTitle = Installazione di {#MyAppName} {#MyAppVersion}
 ko.SetupWindowTitle = 설치 - {#MyAppName} {#MyAppVersion}
 nl.SetupWindowTitle = Setup - {#MyAppName} {#MyAppVersion}
-sk.SetupWindowTitle = Sprievodca inštaláciou - {#MyAppName} {#MyAppVersion}
-
+;
+;
 [CustomMessages]
-en.NotSelfContained=This will install the standard version of %1 version %2.%n%nThis version requires an existing installation of .NET 10 Desktop Runtime and is compatible with both x64 and x86 systems.%n%nIt Is recommended that you close all other applications before continuing.%n%nClick 'Next' to continue, or 'Cancel' to exit Setup.
-en.SelfContainedx86=This will install the self-contained x86 (32-bit) version of %1 version %2.%n%nIt Is recommended that you close all other applications before continuing.%n%nClick 'Next' to continue, or 'Cancel' to exit Setup.
-en.SelfContainedx64=This will install the self-contained x64 (64-bit) version of %1 version %2.%n%nIt Is recommended that you close all other applications before continuing.%n%nClick 'Next' to continue, or 'Cancel' to exit Setup.
+en.NotSelfContained64=This will install the framework-dependent x64 (64-bit) version of %1 version %2.%n%nThis version requires an existing installation of .NET 10 Desktop Runtime.%n%nIt is recommended that you close all other applications before continuing.%n%nClick 'Next' to continue, or 'Cancel' to exit Setup.
+en.SelfContainedx64=This will install the self-contained x64 (64-bit) version of %1 version %2.%n%nIt is recommended that you close all other applications before continuing.%n%nClick 'Next' to continue, or 'Cancel' to exit Setup.
 en.ViewReadme=View the ReadMe file
 en.AppIsRunning=is running, please close it to continue with the installation.
 en.ClearSettings=Do you want to remove the settings and history files and registry entries?%n%nSelect 'No' if you plan to reinstall the program.
-
-ko.NotSelfContained=이렇게 하면 %1 버전 %2의 표준 버전이 설치됩니다.%n%n이 버전은 .NET 10 데스크톱 런타임의 기존 설치가 필요하며 x64 및 x86 시스템과 모두 호환됩니다.%n%n계속하기 전에 다른 모든 응용 프로그램을 닫는 것이 좋습니다.%n%n계속하려면 '다음'을 클릭하거나 설치 프로그램을 종료하려면 '취소'를 클릭합니다.
+;
+;
+ko.NotSelfContained64=이렇게 하면 %1 버전 %2의 프레임워크 종속 x64 (64비트) 버전이 설치됩니다.%n%n이 버전은 .NET 10 Desktop Runtime의 기존 설치가 필요합니다.%n%n계속하기 전에 다른 모든 응용 프로그램을 닫는 것이 좋습니다.%n%n계속하려면 '다음'을 클릭하거나 설치 프로그램을 종료하려면 '취소'를 클릭합니다.
 ko.SelfContainedx64=이렇게 하면 %1 버전 %2의 독립 실행형 x64 (64비트) 버전이 설치됩니다.%n%n계속하기 전에 다른 모든 응용 프로그램을 닫는 것이 좋습니다.%n%n계속하려면 '다음'을 클릭하거나 설치 프로그램을 종료하려면 '취소'를 클릭합니다.
-ko.SelfContainedx86=이렇게 하면 %1 버전 %2의 독립 실행형 x86 (32비트) 버전이 설치됩니다.%n%n계속하기 전에 다른 모든 응용 프로그램을 닫는 것이 좋습니다.%n%n계속하려면 '다음'을 클릭하거나 설치 프로그램을 종료하려면 '취소'를 클릭합니다.
 ko.ViewReadme=ReadMe 파일 보기
 ko.AppIsRunning=가 실행 중입니다. 설치를 계속하려면 닫으세요.
-ko.DeleteConfigFiles=설정 및 기록 파일과 레지스트리 항목을 제거하시겠습니까?%n%n프로그램을 다시 설치할 계획이면 '아니오'를 선택하세요.
-
-es.NotSelfContained=Esto instalará la versión estándar de la versión %2 de %1.%n%nEsta versión requiere una instalación existente de .NET 10 Desktop Runtime y es compatible con los sistemas x64 y x86.%n%nSe recomienda cerrar todas las demás aplicaciones antes de continuar.%n%nHaga clic en 'Siguiente' para continuar o en 'Cancelar' para salir de la configuración.
-es.SelfContainedx86=Esto instalará la versión x86 (32 bits) independiente de la versión %2 de %1.%n%nSe recomienda cerrar todas las demás aplicaciones antes de continuar.%n%nHaga clic en 'Siguiente' para continuar o en 'Cancelar' para salir de la configuración.
-es.SelfContainedx64=Esto instalará la versión x64 (64 bits) independiente de la versión %2 de %1.%n%nSe recomienda cerrar todas las demás aplicaciones antes de continuar.%n%nHaga clic en 'Siguiente' para continuar o en 'Cancelar' para salir de la configuración.
+ko.ClearSettings=설정 및 기록 파일과 레지스트리 항목을 제거하시겠습니까?%n%n프로그램을 다시 설치할 계획이면 '아니오'를 선택하세요.
+;
+;
+es.NotSelfContained64=Esto instalará la versión x64 (64 bits) dependiente del marco de %1 versión %2.%n%nEsta versión requiere una instalación existente de .NET 10 Desktop Runtime.%n%nSe recomienda cerrar todas las demás aplicaciones antes de continuar.%n%nHaga clic en 'Siguiente' para continuar o en 'Cancelar' para salir de la configuración.
+es.SelfContainedx64=Esto instalará la versión x64 (64 bits) independiente portátil de %1 versión %2.%n%nSe recomienda cerrar todas las demás aplicaciones antes de continuar.%n%nHaga clic en 'Siguiente' para continuar o en 'Cancelar' para salir de la configuración.
 es.ViewReadme=Abrir el archivo Léame
 es.AppIsRunning=se está ejecutando, por favor ciérrelo para continuar con la instalación.
-es.ClearSettings=¿Desea eliminar la configuración y excluir archivos?%n%nSeleccione 'No' si planea reinstalar.
-
-it.NotSelfContained=Verrà installata la versione standard di %1 versione %2.%n%nQuesta versione richiede che sia già installato .NET 10 Desktop Runtime ed è compatibile con i sistemi 32bit e 64bit.%n%nPrima di continuare l'instalalzione ti consigliamo di chiudere tutte le altre applicazioni.%n%nSeleziona 'Avanti' per continuare o 'Annulla' per uscire dall'installazione.
-it.SelfContainedx86=Verrà installata la versione standalone di %1 versione %2 32 bit.%n%nPrima di continuare l'instalalzione ti consigliamo di chiudere tutte le altre applicazioni.%n%nSelziona 'Avanti' per continuare o 'Annulla' per uscire dall'installazione.
-it.SelfContainedx64=Verrà installata la versione standalone di %1 versione %2 64 bit.%n%nPrima di continuare l'instalalzione ti consigliamo di chiudere tutte le altre applicazioni.%n%nSeleziona 'Avanti' per continuare o 'Annulla' per uscire dall'installazione.
+es.ClearSettings=¿Desea eliminar la configuración y los archivos de historial y entradas del registro?%n%nSeleccione 'No' si planea reinstalar el programa.
+;
+;
+it.NotSelfContained64=Verrà installata la versione x64 (64 bit) dipendente dal framework di %1 versione %2.%n%nQuesta versione richiede che sia già installato .NET 10 Desktop Runtime.%n%nPrima di continuare l'installazione ti consigliamo di chiudere tutte le altre applicazioni.%n%nSeleziona 'Avanti' per continuare o 'Annulla' per uscire dall'installazione.
+it.SelfContainedx64=Verrà installata la versione x64 (64 bit) standalone portabile di %1 versione %2.%n%nPrima di continuare l'installazione ti consigliamo di chiudere tutte le altre applicazioni.%n%nSeleziona 'Avanti' per continuare o 'Annulla' per uscire dall'installazione.
 it.ViewReadme=Visualizza file ReadMe
-it.AppIsRunning=è in esecuzione.%nChiudilo per poter continuare l'installazione.
-it.ClearSettings=Vuoi rimuovere le impostazioni, i file cronologia e le voci del registro?%n%nSeleziona "No" se hai intenzione di reinstallare il programma.
-
-nl.NotSelfContained=Hiermee wordt de standaardversie van %1 versie %2 geïnstalleerd.%n%n%nDeze versie vereist een bestaande installatie van .NET 10 Desktop Runtime en is compatibel met zowel x64- als x86-systemen.%n%nHet wordt aanbevolen om alle andere toepassingen te sluiten voordat u doorgaat.%n%nKlik op 'volgende' om door te gaan of op 'annuleren' om de installatie af te sluiten.
-nl.SelfContainedx86=Hiermee wordt de portable x86 (32-bits) versie van %1 versie %2 geïnstalleerd.%n%n%nHet wordt aanbevolen om alle andere toepassingen te sluiten voordat u doorgaat.%n%nKlik op 'volgende' om door te gaan of op 'annuleren' om de installatie af te sluiten.
-nl.SelfContainedx64= Hiermee wordt de portable x64 (64-bits) versie van %1 versie %2 geïnstalleerd.%n%n%nHet wordt aanbevolen om alle andere toepassingen te sluiten voordat u doorgaat.%n%nKlik op 'volgende' om door te gaan of op 'annuleren' om de installatie af te sluiten.
+it.AppIsRunning=è in esecuzione. Chiudilo per poter continuare l'installazione.
+it.ClearSettings=Vuoi rimuovere le impostazioni, i file cronologia e le voci del registro?%n%nSeleziona 'No' se hai intenzione di reinstallare il programma.
+;
+;
+nl.NotSelfContained64=Hiermee wordt de x64 (64-bits) frameworkafhankelijke versie van %1 versie %2 geïnstalleerd.%n%nDeze versie vereist een bestaande installatie van .NET 10 Desktop Runtime.%n%nHet wordt aanbevolen om alle andere toepassingen te sluiten voordat u doorgaat.%n%nKlik op 'Volgende' om door te gaan of op 'Annuleren' om de installatie af te sluiten.
+nl.SelfContainedx64=Hiermee wordt de draagbare x64 (64-bits) zelfstandige versie van %1 versie %2 geïnstalleerd.%n%nHet wordt aanbevolen om alle andere toepassingen te sluiten voordat u doorgaat.%n%nKlik op 'Volgende' om door te gaan of op 'Annuleren' om de installatie af te sluiten.
 nl.ViewReadme=Open de ReadMe file
 nl.AppIsRunning=wordt uitgevoerd, sluit deze dan af om door te gaan met de installatie.
-nl.ClearSettings=Wilt u de instellingen, data bestanden en registerwaarden verwijderen?%n%nKies 'NEE' als u het programma opnieuw wilt installeren.
-
-sk.ViewReadme=Zobraziť súbor ReadMe
-sk.AppIsRunning=beží, zatvorte ho, aby ste mohli pokračovať v inštalácii.
-sk.ClearSettings=Chcete odstrániť súbory nastavení?%n%nAk plánujete preinštalovať, vyberte 'Nie'.
+nl.ClearSettings=Wilt u de instellingen, gegevensbestanden en registerwaarden verwijderen?%n%nKies 'NEE' als u het programma opnieuw wilt installeren.

--- a/TimVer/Properties/PublishProfiles/Framework_Dependent.pubxml
+++ b/TimVer/Properties/PublishProfiles/Framework_Dependent.pubxml
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project>
+  <PropertyGroup>
+    <_TargetId>Folder</_TargetId>
+    <Configuration>Release</Configuration>
+    <Platform>x64</Platform>
+    <PublishDir>V:\Publish\TimVer\Framework_Dependent_x64</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <PublishReadyToRun>false</PublishReadyToRun>
+    <PublishSingleFile>false</PublishSingleFile>
+    <PublishTrimmed>false</PublishTrimmed>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <SelfContained>false</SelfContained>
+    <TargetFramework>net10.0-windows</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/TimVer/Properties/PublishProfiles/Self_Contained_x64.pubxml
+++ b/TimVer/Properties/PublishProfiles/Self_Contained_x64.pubxml
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project>
+  <PropertyGroup>
+    <_TargetId>Folder</_TargetId>
+    <Configuration>Release</Configuration>
+    <Platform>x64</Platform>
+    <PublishDir>V:\Publish\TimVer\Self_Contained_x64</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <PublishReadyToRun>false</PublishReadyToRun>
+    <PublishSingleFile>false</PublishSingleFile>
+    <PublishTrimmed>false</PublishTrimmed>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <SelfContained>true</SelfContained>
+    <TargetFramework>net10.0-windows</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/TimVer/TimVer.csproj
+++ b/TimVer/TimVer.csproj
@@ -15,12 +15,19 @@
     <CsWinRTAotOptimizerEnabled>false</CsWinRTAotOptimizerEnabled>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
+  
+  <!-- x64 Only-->
+  <PropertyGroup>
+    <Platforms>x64</Platforms>
+    <PlatformTarget>x64</PlatformTarget>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+  </PropertyGroup>
 
   <!-- Set version and prerelease string (if needed) -->
   <PropertyGroup>
     <VersionValidate>true</VersionValidate>
-    <Version>0.13.0</Version>
-    <VersionPrerelease>PreRelease</VersionPrerelease>
+    <Version>0.14.0</Version>
+    <VersionPrerelease></VersionPrerelease>
   </PropertyGroup>
 
   <!-- Analyzers -->
@@ -53,7 +60,7 @@
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     <PackageReference Include="MaterialDesignThemes" Version="5.3.2" />
     <PackageReference Include="Microsoft.Management.Infrastructure" Version="3.0.0" />
-    <PackageReference Include="VersionInfoGenerator" Version="3.2.1" PrivateAssets="all"/>
+    <PackageReference Include="VersionInfoGenerator" Version="3.2.1" PrivateAssets="all" />
     <PackageReference Include="NLog" Version="6.1.4" />
     <PackageReference Include="Octokit" Version="14.0.0" />
   </ItemGroup>


### PR DESCRIPTION
Update to x64 architecture
- Set solution/project to x64 only (PlatformTarget, RuntimeIdentifier, Platforms)
- Add x64 Framework-Dependent and Self-Contained publish profiles
- Update .gitignore to allow specific pubxml files
- Revise installer scripts: remove x86/mixed, clarify x64 build messages, update localization strings
- See #132 for additional info