### PR TITLE
Improve date parsing and user profile path handling

### DIFF
--- a/TimVer/BuildInfo.cs
+++ b/TimVer/BuildInfo.cs
@@ -14,11 +14,18 @@ internal static class BuildInfo
 
     public static readonly string? Prerelease = VersionInfo.VersionPrerelease;
 
+    /// <summary>
+    /// The UTC date and time of the last commit. Returns <see cref="DateTime.MinValue"/>
+    /// if the commit date cannot be parsed.
+    /// </summary>
     public static readonly DateTime CommitDateUtc =
-        DateTime.Parse(
+        DateTime.TryParse(
             VersionInfo.GitCommitterDate,
             CultureInfo.InvariantCulture,
-            DateTimeStyles.AdjustToUniversal);
+            DateTimeStyles.AdjustToUniversal,
+            out DateTime parsedDate)
+        ? parsedDate
+        : DateTime.MinValue;
 
     public static readonly string CommitDateStringUtc = $"{CommitDateUtc:f} (UTC)";
     public static readonly string CommitDateStringLocal = $"{CommitDateUtc.ToLocalTime():f} (Local)";

--- a/TimVer/Helpers/PathHelpers.cs
+++ b/TimVer/Helpers/PathHelpers.cs
@@ -22,10 +22,17 @@ internal static class PathHelpers
         }
 
         string userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-        if (!path.StartsWith(userProfile, StringComparison.CurrentCultureIgnoreCase))
+        if (!path.StartsWith(userProfile, StringComparison.OrdinalIgnoreCase))
         {
             return path;
         }
-        return path.Replace(userProfile, "%USERPROFILE%");
+        int profileLength = userProfile.Length;
+        if (profileLength < path.Length &&
+            path[profileLength] != Path.DirectorySeparatorChar &&
+            path[profileLength] != Path.AltDirectorySeparatorChar)
+        {
+            return path;
+        }
+        return "%USERPROFILE%" + path[profileLength..];
     }
 }


### PR DESCRIPTION
### PR Summary

- Use DateTime.TryParse for BuildInfo.CommitDateUtc to avoid exceptions; return DateTime.MinValue on failure and document behavior.
- In PathHelpers.GetUserProfileRelativePath, switch to OrdinalIgnoreCase for path comparison and refine logic to only replace user profile path when followed by a separator, preventing partial matches.