### PR TITLE
Refactor AppInfo and BuildInfo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -344,6 +344,7 @@ healthchecksdb
 
 # override .gitignore_global 
 !TimVer/BuildInfo.cs
+
 !**/*.pubxml
 
 # Error list

--- a/TimVer/Helpers/AppInfo.cs
+++ b/TimVer/Helpers/AppInfo.cs
@@ -8,9 +8,68 @@ namespace TimVer.Helpers;
 internal static class AppInfo
 {
     /// <summary>
-    /// Returns the process architecture e.g. X64, Arm64, etc.
+    /// Returns the process architecture e.g. x64, Arm64, etc.
+    /// x86 and x64 are returned in lowercase, all other architectures are returned as-is.
     /// </summary>
-    public static string Architecture => RuntimeInformation.ProcessArchitecture.ToString();
+    public static string Architecture
+    {
+        get
+        {
+            field = RuntimeInformation.ProcessArchitecture.ToString();
+            return field.ToLowerInvariant() switch
+            {
+                "x64" => "x64",
+                "x86" => "x86",
+                _ => field
+            };
+        }
+    }
+
+    /// <summary>
+    /// Returns the Copyright info from the Assembly info
+    /// </summary>
+    public static string AppCopyright => FileVersionInfo.GetVersionInfo(Assembly.GetEntryAssembly()!.Location).LegalCopyright ?? "missing";
+
+    /// <summary>
+    /// Returns the app's full path excluding the EXE name
+    /// </summary>
+    public static string AppDirectory => Path.GetDirectoryName(Assembly.GetEntryAssembly()!.Location) ?? "missing";
+
+    /// <summary>
+    /// Returns the app's name without the extension
+    /// </summary>
+    public static string AppName => (Assembly.GetEntryAssembly()!.GetName().Name) ?? "missing";
+
+    /// <summary>
+    /// Returns the app's full path including the EXE name
+    /// </summary>
+    public static string AppPath => Environment.ProcessPath!;
+
+    /// <summary>
+    /// Returns the Process ID as Int
+    /// </summary>
+    public static int AppProcessID => Environment.ProcessId;
+
+    /// <summary>
+    /// Returns the Product Name from the Assembly info
+    /// </summary>
+    public static string AppProduct => FileVersionInfo.GetVersionInfo(Assembly.GetEntryAssembly()!.Location).ProductName ?? "missing";
+
+    /// <summary>
+    /// Returns the product version from the Assembly info
+    /// </summary>
+    // Used in About window XAML tooltip: Views/AboutPage.xaml.
+    public static string AppProductVersion => FileVersionInfo.GetVersionInfo(Assembly.GetEntryAssembly()!.Location).ProductVersion ?? "missing";
+
+    /// <summary>
+    /// Returns the full version number as Version
+    /// </summary>
+    public static Version AppVersionVer => Assembly.GetEntryAssembly()!.GetName().Version!;
+
+    /// <summary>
+    /// True if running as administrator
+    /// </summary>
+    public static bool IsAdmin => new WindowsPrincipal(WindowsIdentity.GetCurrent()).IsInRole(WindowsBuiltInRole.Administrator);
 
     /// <summary>
     /// Returns the operating system description e.g. Microsoft Windows 10.0.19044
@@ -21,49 +80,4 @@ internal static class AppInfo
     /// Returns the framework description
     /// </summary>
     public static string RuntimeVersion => RuntimeInformation.FrameworkDescription;
-
-    /// <summary>
-    /// Returns the full version number as Version
-    /// </summary>
-    public static Version AppVersionVer => Assembly.GetEntryAssembly()!.GetName().Version!;
-
-    /// <summary>
-    /// Returns the app's full path including the EXE name
-    /// </summary>
-    public static string AppPath => Environment.ProcessPath!;
-
-    /// <summary>
-    /// Returns the app's full path excluding the EXE name
-    /// </summary>
-    public static string AppDirectory => Path.GetDirectoryName(Assembly.GetEntryAssembly()!.Location) ?? "missing";
-
-    /// <summary>
-    /// Returns the app's name without the extension
-    /// </summary>
-    public static string AppName => Assembly.GetEntryAssembly()!.GetName().Name ?? "missing";
-
-    /// <summary>
-    /// Returns the product version from the Assembly info
-    /// </summary>
-    public static string AppProductVersion => FileVersionInfo.GetVersionInfo(Assembly.GetEntryAssembly()!.Location).ProductVersion ?? "missing";
-
-    /// <summary>
-    /// Returns the Copyright info from the Assembly info
-    /// </summary>
-    public static string AppCopyright => FileVersionInfo.GetVersionInfo(Assembly.GetEntryAssembly()!.Location).LegalCopyright ?? "missing";
-
-    /// <summary>
-    /// Returns the Product Name from the Assembly info
-    /// </summary>
-    public static string AppProduct => FileVersionInfo.GetVersionInfo(Assembly.GetEntryAssembly()!.Location).ProductName ?? "missing";
-
-    /// <summary>
-    /// Returns the Process ID as Int
-    /// </summary>
-    public static int AppProcessID => Environment.ProcessId;
-
-    /// <summary>
-    /// True if running as administrator
-    /// </summary>
-    public static bool IsAdmin => new WindowsPrincipal(WindowsIdentity.GetCurrent()).IsInRole(WindowsBuiltInRole.Administrator);
 }

--- a/TimVer/Helpers/BuildInfo.cs
+++ b/TimVer/Helpers/BuildInfo.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Tim Kennedy. All Rights Reserved. Licensed under the MIT License.
 
-namespace TimVer;
+namespace TimVer.Helpers;
 
 /// <summary>
 /// BuildInfo class provides information about the build, including commit ID, commit date, and version string.

--- a/TimVer/TimVer.csproj
+++ b/TimVer/TimVer.csproj
@@ -26,7 +26,7 @@
   <!-- Set version and prerelease string (if needed) -->
   <PropertyGroup>
     <VersionValidate>true</VersionValidate>
-    <Version>0.14.1</Version>
+    <Version>0.14.2</Version>
     <VersionPrerelease></VersionPrerelease>
   </PropertyGroup>
 

--- a/TimVer/Views/AboutPage.xaml
+++ b/TimVer/Views/AboutPage.xaml
@@ -79,7 +79,7 @@
                 <TextBlock Grid.Row="1" Grid.Column="0"
                            Text="{DynamicResource About_Version}" />
                 <TextBlock Grid.Row="1" Grid.Column="2"
-                           Text="{x:Static local:BuildInfo.VersionString}"
+                           Text="{x:Static helpers:BuildInfo.VersionString}"
                            TextWrapping="Wrap"
                            ToolTip="{x:Static helpers:AppInfo.AppProductVersion}"
                            ToolTipService.Placement="Top" />
@@ -119,21 +119,21 @@
                            Text="{DynamicResource About_BuildDate}" />
                 <StackPanel Grid.Row="5" Grid.Column="2"
                             Orientation="Horizontal">
-                    <TextBlock Text="{Binding Source={x:Static local:BuildInfo.CommitDateStringUtc}}" />
+                    <TextBlock Text="{Binding Source={x:Static helpers:BuildInfo.CommitDateStringUtc}}" />
                 </StackPanel>
 
                 <TextBlock Grid.Row="6" Grid.Column="0"
                            Text="{DynamicResource About_CommitID}" />
                 <TextBlock Grid.Row="6" Grid.Column="2"
                            HorizontalAlignment="Left"
-                           Text="{x:Static local:BuildInfo.CommitIDString}"
+                           Text="{x:Static helpers:BuildInfo.CommitIDString}"
                            TextWrapping="Wrap"
                            ToolTipService.Placement="Top">
                     <TextBlock.ToolTip>
                         <ToolTip>
                             <TextBlock>
                                 <Run Text="{DynamicResource About_CommitIDToolTip}" />
-                                <Run Text="{x:Static local:BuildInfo.CommitIDFullString}" />
+                                <Run Text="{x:Static helpers:BuildInfo.CommitIDFullString}" />
                             </TextBlock>
                         </ToolTip>
                     </TextBlock.ToolTip>

--- a/TimVer/Views/AboutPage.xaml
+++ b/TimVer/Views/AboutPage.xaml
@@ -78,11 +78,16 @@
 
                 <TextBlock Grid.Row="1" Grid.Column="0"
                            Text="{DynamicResource About_Version}" />
-                <TextBlock Grid.Row="1" Grid.Column="2"
+                <StackPanel Grid.Row="1" Grid.Column="2"
+                            Orientation="Horizontal">
+                    <TextBlock 
                            Text="{x:Static helpers:BuildInfo.VersionString}"
                            TextWrapping="Wrap"
                            ToolTip="{x:Static helpers:AppInfo.AppProductVersion}"
                            ToolTipService.Placement="Top" />
+                    <TextBlock Text="{Binding Source={x:Static helpers:AppInfo.Architecture}, StringFormat='({0})'}" Margin="10,0,0,0" />
+                </StackPanel>
+
 
                 <TextBlock Grid.Row="2" Grid.Column="0"
                            Text="{DynamicResource About_CreatedBy}" />


### PR DESCRIPTION
### In AppInfo
- Refactor Architecture
  - Return x64 and x86 in lowercase
  - Add architecture to About page
- Remove unused properties
- Sort properties by name

### In BuildInfo
- Moved BuildInfo.cs from TimVer to TimVer.Helpers to clean up project root.
- Updated all AboutPage.xaml references from local:BuildInfo to helpers:BuildInfo to match the new namespace.
- No logic changes; only namespace and reference updates.