### PR TITLE
Add PathHelpers.FindOnPath to increase resiliency and handle nonstandard file locations

### DIFF
--- a/TimVer/Helpers/PathHelpers.cs
+++ b/TimVer/Helpers/PathHelpers.cs
@@ -35,4 +35,53 @@ internal static class PathHelpers
         }
         return "%USERPROFILE%" + path[profileLength..];
     }
+
+    #region Search PATH for a file
+    /// <summary>
+    /// Find a file name in the path and optionally, the current directory.
+    /// </summary>
+    /// <param name="filename">File name to search for</param>
+    /// <param name="includeCurrentDirectory">Whether to include the current directory in the search</param>
+    /// <returns>Path to the file if found; otherwise, an empty string</returns>
+    /// <remarks>
+    /// This method searches for the specified file in the directories listed in the PATH environment variable.
+    /// If includeCurrentDirectory is true, it also searches in the current directory.
+    /// There are potential security risks associated with including the current directory in the search, as it
+    /// may lead to executing unintended files. Use this option with caution.
+    /// </remarks>
+    /// <exception cref="ArgumentException">Thrown when the filename is null, empty, contains invalid characters, has no extension, or is a rooted path.</exception>
+    public static string FindOnPath(string filename, bool includeCurrentDirectory = false)
+    {
+        if (string.IsNullOrEmpty(filename) || filename.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+        {
+            throw new ArgumentException("Filename cannot be null, empty, or contain invalid characters.", nameof(filename));
+        }
+        if (Path.GetExtension(filename) == string.Empty)
+        {
+            throw new ArgumentException("Filename must have an extension.", nameof(filename));
+        }
+        if (Path.IsPathRooted(filename))
+        {
+            throw new ArgumentException("Filename must not be a rooted path.", nameof(filename));
+        }
+        string pathVar = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
+        string[] folders = pathVar.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries);
+
+        if (includeCurrentDirectory)
+        {
+            folders = [Environment.CurrentDirectory, .. folders];
+        }
+
+        foreach (string folder in folders)
+        {
+            string path = Path.Combine(folder.Trim('\"'), filename);
+            if (File.Exists(path))
+            {
+                return path;
+            }
+        }
+
+        return string.Empty;
+    }
+    #endregion Search PATH for a file
 }

--- a/TimVer/Helpers/TextFileViewer.cs
+++ b/TimVer/Helpers/TextFileViewer.cs
@@ -12,11 +12,6 @@ namespace TimVer.Helpers;
 internal static class TextFileViewer
 {
     #region Text file viewer
-    /// <summary>
-    /// Opens specified text file
-    /// </summary>
-    /// <param name="textFile">Full path for text file</param>
-    ///
     public static void ViewTextFile(string textFile)
     {
         string fname = string.Empty;
@@ -25,7 +20,7 @@ internal static class TextFileViewer
             fname = PathHelpers.AnonymizePath(textFile);
 
             using Process p = new();
-            p.StartInfo.FileName = textFile;
+            p.StartInfo.FileName = $"\"{textFile}\"";
             p.StartInfo.UseShellExecute = true;
             p.StartInfo.ErrorDialog = false;
             _ = p.Start();
@@ -33,11 +28,23 @@ internal static class TextFileViewer
         }
         catch (Win32Exception ex)
         {
-            if (ex.NativeErrorCode == 1155)
+            int ERROR_NO_ASSOCIATION = 1155;
+            if (ex.NativeErrorCode == ERROR_NO_ASSOCIATION)
             {
+                string notepadPath = PathHelpers.FindOnPath("notepad.exe", false);
+                if (string.IsNullOrEmpty(notepadPath))
+                {
+                    _log.Error($"Unable to find notepad.exe in PATH");
+                    string msg = string.Format(CultureInfo.InvariantCulture, MsgTextErrorOpeningFile, textFile);
+                    _ = MessageBox.Show($"{msg}\n\nUnable to find notepad.exe in PATH",
+                                        GetStringResource("MsgText_ErrorCaption"),
+                                        MessageBoxButton.OK,
+                                        MessageBoxImage.Error);
+                    return;
+                }
                 using Process p = new();
-                p.StartInfo.FileName = "notepad.exe";
-                p.StartInfo.Arguments = textFile;
+                p.StartInfo.FileName = notepadPath;
+                p.StartInfo.Arguments = $"\"{textFile}\"";
                 p.StartInfo.UseShellExecute = true;
                 p.StartInfo.ErrorDialog = false;
                 _ = p.Start();
@@ -45,9 +52,9 @@ internal static class TextFileViewer
             }
             else
             {
-#if messagebox
                 string msg = string.Format(CultureInfo.InvariantCulture, MsgTextErrorOpeningFile, textFile);
-                _ = MessageBox.Show($"{msg}\n{ex.Message}",
+#if messagebox
+                _ = MessageBox.Show($"{msg}\n\n{ex.Message}",
                                     GetStringResource("MsgText_ErrorCaption"),
                                     MessageBoxButton.OK,
                                     MessageBoxImage.Error);
@@ -57,14 +64,14 @@ internal static class TextFileViewer
         }
         catch (Exception ex)
         {
-#if messagebox
             string msg = string.Format(CultureInfo.InvariantCulture, MsgTextErrorOpeningFile, textFile);
-            _ = MessageBox.Show($"{msg}\n{ex.Message}",
+#if messagebox
+            _ = MessageBox.Show($"{msg}\n\n{ex.Message}",
                                 GetStringResource("MsgText_ErrorCaption"),
                                 MessageBoxButton.OK,
                                 MessageBoxImage.Error);
 #endif
-            _log.Error(ex, $"Unable to open {fname}");
+            _log.Error($"Unable to open {fname}. {ex.Message} ");
         }
     }
     #endregion Text file viewer

--- a/TimVer/ViewModels/NavigationViewModel.cs
+++ b/TimVer/ViewModels/NavigationViewModel.cs
@@ -170,9 +170,24 @@ internal sealed partial class NavigationViewModel : ObservableObject
     [RelayCommand]
     private static void OpenAppFolder()
     {
+        string fileName = PathHelpers.FindOnPath("Explorer.exe");
+        if (fileName == string.Empty)
+        {
+            _log.Error("Error trying to open application folder: Explorer.exe not found");
+            string msg = $"{GetStringResource("MsgText_Error_FileExplorer")}" +
+                         $"\n\n{GetStringResource("MsgText_SeeLogFile")}";
+            _ = new MDCustMsgBox(msg,
+                     GetStringResource("MsgText_ErrorCaption"),
+                     ButtonType.Ok,
+                     false,
+                     true,
+                     _mainWindow,
+                     true).ShowDialog();
+            return;
+        }
         using Process process = new();
         process.StartInfo.UseShellExecute = false;
-        process.StartInfo.FileName = "Explorer.exe";
+        process.StartInfo.FileName = fileName;
         process.StartInfo.Arguments = AppInfo.AppDirectory;
         _ = process.Start();
     }

--- a/TimVer/ViewModels/SettingsViewModel.cs
+++ b/TimVer/ViewModels/SettingsViewModel.cs
@@ -46,7 +46,22 @@ internal sealed partial class SettingsViewModel : ObservableObject
             filePath = Path.Combine(AppInfo.AppDirectory, "Strings.test.xaml");
             if (File.Exists(filePath))
             {
-                _ = Process.Start("explorer.exe", $"/select,\"{filePath}\"");
+                string explorerPath = PathHelpers.FindOnPath("explorer.exe");
+                if (string.IsNullOrEmpty(explorerPath))
+                {
+                    _log.Error($"Error trying to open {filePath}: Explorer.exe not found");
+                    string msg = $"{GetStringResource("MsgText_Error_FileExplorer")}" +
+                                 $"\n\n{GetStringResource("MsgText_SeeLogFile")}";
+                    _ = new MDCustMsgBox(msg,
+                             GetStringResource("MsgText_ErrorCaption"),
+                             ButtonType.Ok,
+                             false,
+                             true,
+                             _mainWindow,
+                             true).ShowDialog();
+                    return;
+                }
+                Process.Start(explorerPath, $"/select,\"{filePath}\"");
             }
             else
             {
@@ -69,7 +84,7 @@ internal sealed partial class SettingsViewModel : ObservableObject
                      true).ShowDialog();
         }
     }
-    #endregion
+    #endregion Open folder
 
     #region Open settings
     [RelayCommand]


### PR DESCRIPTION
#### Add PathHelpers.FindOnPath to increase resiliency and handle nonstandard file locations

- Added PathHelpers.FindOnPath to search for files in the system PATH, optionally including the current directory.
- Refactored TextFileViewer, NavigationViewModel and SettingsViewModel to use this method for locating notepad.exe and explorer.exe, respectively.
- Improved error handling and user notification if explorer.exe is not found.