### PR TITLE
Remove nullable Setting refs; enforce non-null access

### DIFF
--- a/TimVer/App.xaml.cs
+++ b/TimVer/App.xaml.cs
@@ -58,7 +58,7 @@ public partial class App : Application
             string currentLanguage = Thread.CurrentThread.CurrentCulture.Name;
 
             // If option to use OS language is true and it exists in the list of defined languages, use it but do not change current culture.
-            if (UserSettings.Setting!.UseOSLanguage &&
+            if (UserSettings.Setting.UseOSLanguage &&
                 UILanguage.DefinedLanguages.Exists(x => x.LanguageCode == currentLanguage))
             {
                 resDict.Source = new Uri($"Languages/Strings.{currentLanguage}.xaml", UriKind.RelativeOrAbsolute);
@@ -114,7 +114,7 @@ public partial class App : Application
     #region Language testing
     private void CheckLanguageTesting()
     {
-        if (UserSettings.Setting!.LanguageTesting)
+        if (UserSettings.Setting.LanguageTesting)
         {
             _log.Info("Language testing enabled");
             ResourceDictionary testDict = [];

--- a/TimVer/Configuration/ConfigManager.cs
+++ b/TimVer/Configuration/ConfigManager.cs
@@ -8,5 +8,10 @@ namespace TimVer.Configuration;
 /// <typeparam name="T">Class name of user settings</typeparam>
 public abstract class ConfigManager<T> where T : ConfigManager<T>, new()
 {
-    public static T? Setting { get; set; }
+    public static T Setting
+    {
+        get => field ?? throw new InvalidOperationException($"{typeof(T).Name}.Setting is not initialized.");
+
+        set => field = value ?? throw new ArgumentNullException(nameof(value));
+    }
 }

--- a/TimVer/Configuration/SettingChange.cs
+++ b/TimVer/Configuration/SettingChange.cs
@@ -31,12 +31,12 @@ public static class SettingChange
                 break;
 
             case nameof(UserSettings.Setting.UISize):
-                MainWindowHelpers.UIScale(UserSettings.Setting!.UISize);
+                MainWindowHelpers.UIScale(UserSettings.Setting.UISize);
                 break;
 
             case nameof(UserSettings.Setting.KeepHistory):
                 HistoryHelpers.WriteHistory();
-                if (!(bool)newValue! && UserSettings.Setting!.InitialPage == NavPage.History)
+                if (!(bool)newValue! && UserSettings.Setting.InitialPage == NavPage.History)
                 {
                     UserSettings.Setting.InitialPage = NavPage.WindowsInfo;
                     SnackbarMsg.QueueMessage(GetStringResource("MsgText_OptionReset"));
@@ -44,7 +44,7 @@ public static class SettingChange
                 break;
 
             case nameof(UserSettings.Setting.InitialPage):
-                if ((NavPage)newValue! == NavPage.History && !UserSettings.Setting!.KeepHistory)
+                if ((NavPage)newValue! == NavPage.History && !UserSettings.Setting.KeepHistory)
                 {
                     UserSettings.Setting.KeepHistory = true;
                     SnackbarMsg.QueueMessage(GetStringResource("MsgText_OptionReset"));
@@ -77,7 +77,7 @@ public static class SettingChange
 
             case nameof(UserSettings.Setting.SystemLightTheme):
             case nameof(UserSettings.Setting.SystemDarkTheme):
-                if (UserSettings.Setting!.UITheme == ThemeType.System)
+                if (UserSettings.Setting.UITheme == ThemeType.System)
                 {
                     MainWindowHelpers.SetBaseTheme(ThemeType.System);
                 }

--- a/TimVer/Configuration/UserSettings.cs
+++ b/TimVer/Configuration/UserSettings.cs
@@ -6,8 +6,6 @@ namespace TimVer.Configuration;
 public partial class UserSettings : ConfigManager<UserSettings>
 {
     #region Properties (some with default values)
-#pragma warning disable MVVMTK0042 // Prefer using [ObservableProperty] on partial properties
-    // Suppressing the MVVMTK0042 warning for this class until such time as it no longer requires Preview features.
     /// <summary>
     /// Check for updates automatically when About page is opened.
     /// </summary>
@@ -271,6 +269,5 @@ public partial class UserSettings : ConfigManager<UserSettings>
     /// </summary>
     [ObservableProperty]
     private double _windowWidth = 1000;
-#pragma warning restore MVVMTK0042 // Prefer using [ObservableProperty] on partial properties
     #endregion Properties (some with default values)
 }

--- a/TimVer/Helpers/ClipboardHelper.cs
+++ b/TimVer/Helpers/ClipboardHelper.cs
@@ -116,8 +116,8 @@ internal static class ClipboardHelper
 
             case DriveInfoViewModel:
                 {
-                    string giga = UserSettings.Setting!.Use1024 ? "GiB" : "GB";
-                    if (TempSettings.Setting!.DriveSelectedTab == 0)
+                    string giga = UserSettings.Setting.Use1024 ? "GiB" : "GB";
+                    if (TempSettings.Setting.DriveSelectedTab == 0)
                     {
                         _ = builder.Append(GetStringResource("NavTitle_DriveInfo"))
                                    .Append(" - ")

--- a/TimVer/Helpers/DiskDriveHelpers.cs
+++ b/TimVer/Helpers/DiskDriveHelpers.cs
@@ -134,20 +134,20 @@ internal static class DiskDriveHelpers
     {
         // If the drive is network check settings to see if it needs to be included
         if (string.Equals(d.DriveType.ToString(), "network", StringComparison.OrdinalIgnoreCase)
-            && !UserSettings.Setting!.IncludeNetwork)
+            && !UserSettings.Setting.IncludeNetwork)
         {
             return null;
         }
         // If the drive is removable check settings to see if it needs to be included
         if (string.Equals(d.DriveType.ToString(), "removable", StringComparison.OrdinalIgnoreCase)
-            && !UserSettings.Setting!.IncludeRemovable)
+            && !UserSettings.Setting.IncludeRemovable)
         {
             return null;
         }
         // If the drive is ready
         if (d.IsReady)
         {
-            int gbPref = UserSettings.Setting!.Use1024 ? 1024 : 1000;
+            int gbPref = UserSettings.Setting.Use1024 ? 1024 : 1000;
 
             // Add the information for each drive to the list
             return new()
@@ -171,7 +171,7 @@ internal static class DiskDriveHelpers
             };
         }
         // If the drive is not ready
-        else if (UserSettings.Setting!.IncludeNotReady)
+        else if (UserSettings.Setting.IncludeNotReady)
         {
             return new()
             {
@@ -207,7 +207,7 @@ internal static class DiskDriveHelpers
     /// <returns>List of properties and values of type PhysicalDrives</returns>
     public static List<PhysicalDrives> GetPhysicalDriveInfo()
     {
-        if (UserSettings.Setting!.GetPhysicalDrives)
+        if (UserSettings.Setting.GetPhysicalDrives)
         {
             MainWindowHelpers.MainWindowWaitPointer();
             Stopwatch pdWatch = Stopwatch.StartNew();
@@ -295,7 +295,7 @@ internal static class DiskDriveHelpers
         try
         {
             using CimSession cimSession = CimSession.Create(null);
-            int gbPref = UserSettings.Setting!.Use1024 ? 1024 : 1000;
+            int gbPref = UserSettings.Setting.Use1024 ? 1024 : 1000;
             IEnumerable<CimInstance> diskInfo = cimSession.QueryInstances(scope, "WQL", query);
             return diskInfo.Select(drive => new Dictionary<string, string>
             {

--- a/TimVer/Helpers/MainWindowHelpers.cs
+++ b/TimVer/Helpers/MainWindowHelpers.cs
@@ -42,7 +42,7 @@ internal static class MainWindowHelpers
         SetWindowPosition();
 
         // Light or dark theme
-        SetBaseTheme(UserSettings.Setting!.UITheme);
+        SetBaseTheme(UserSettings.Setting.UITheme);
 
         // Primary accent color
         SetPrimaryColor(UserSettings.Setting.PrimaryColor);
@@ -59,7 +59,7 @@ internal static class MainWindowHelpers
     private static void SetWindowPosition()
     {
         Window? mainWindow = Application.Current.MainWindow;
-        mainWindow!.Height = UserSettings.Setting!.WindowHeight;
+        mainWindow.Height = UserSettings.Setting.WindowHeight;
         mainWindow.Left = UserSettings.Setting.WindowLeft;
         mainWindow.Top = UserSettings.Setting.WindowTop;
         mainWindow.Width = UserSettings.Setting.WindowWidth;
@@ -97,7 +97,7 @@ internal static class MainWindowHelpers
     private static void SaveWindowPosition()
     {
         Window? mainWindow = Application.Current.MainWindow;
-        UserSettings.Setting!.WindowHeight = Math.Floor(mainWindow!.Height);
+        UserSettings.Setting.WindowHeight = Math.Floor(mainWindow.Height);
         UserSettings.Setting.WindowLeft = Math.Floor(mainWindow.Left);
         UserSettings.Setting.WindowTop = Math.Floor(mainWindow.Top);
         UserSettings.Setting.WindowWidth = Math.Floor(mainWindow.Width);
@@ -124,8 +124,8 @@ internal static class MainWindowHelpers
     private static void EventHandlers()
     {
         // Settings change events
-        UserSettings.Setting!.PropertyChanged += SettingChange.UserSettingChanged!;
-        TempSettings.Setting!.PropertyChanged += SettingChange.TempSettingChanged!;
+        UserSettings.Setting.PropertyChanged += SettingChange.UserSettingChanged!;
+        TempSettings.Setting.PropertyChanged += SettingChange.TempSettingChanged!;
 
         // Window closing event
         _mainWindow!.Closing += MainWindow_Closing!;
@@ -217,8 +217,8 @@ internal static class MainWindowHelpers
         {
             var systemTheme = GetSystemTheme();
             mode = systemTheme.Equals("light", StringComparison.OrdinalIgnoreCase)
-                ? UserSettings.Setting!.SystemLightTheme
-                : UserSettings.Setting!.SystemDarkTheme;
+                ? UserSettings.Setting.SystemLightTheme
+                : UserSettings.Setting.SystemDarkTheme;
 
             // Guard against invalid config values (e.g., System) so we always apply a concrete theme.
             if (mode == ThemeType.System)
@@ -347,7 +347,7 @@ internal static class MainWindowHelpers
     /// </summary>
     public static void EverythingSmaller()
     {
-        MySize size = UserSettings.Setting!.UISize;
+        MySize size = UserSettings.Setting.UISize;
         if (size > 0)
         {
             size--;
@@ -361,7 +361,7 @@ internal static class MainWindowHelpers
     /// </summary>
     public static void EverythingLarger()
     {
-        MySize size = UserSettings.Setting!.UISize;
+        MySize size = UserSettings.Setting.UISize;
         if (size < MySize.Largest)
         {
             size++;
@@ -423,7 +423,7 @@ internal static class MainWindowHelpers
         if (parsedArgs == CommandLineHelpers.CommandLineArgs.Hide)
         {
             UpdateHistoryOnly = true;
-            if (UserSettings.Setting!.KeepHistory)
+            if (UserSettings.Setting.KeepHistory)
             {
                 _log.Debug("Command line argument \"hide\" specified. Will update build history log if needed. ");
                 HistoryHelpers.WriteHistory();
@@ -436,7 +436,7 @@ internal static class MainWindowHelpers
         }
 
         ApplyUISettings();
-        TempSettings.Setting!.RunAccessPermitted = RegistryHelpers.RegRunAccessPermitted();
+        TempSettings.Setting.RunAccessPermitted = RegistryHelpers.RegRunAccessPermitted();
     }
     #endregion Check command line
 }

--- a/TimVer/Helpers/NLogHelpers.cs
+++ b/TimVer/Helpers/NLogHelpers.cs
@@ -72,7 +72,7 @@ internal static class NLogHelpers
         LogManager.Configuration = config;
 
         // Lastly, set the logging level based on setting
-        SetLogLevel(UserSettings.Setting!.IncludeDebug);
+        SetLogLevel(UserSettings.Setting.IncludeDebug);
     }
     #endregion Create the NLog configuration
 

--- a/TimVer/Helpers/WindowsInfoHelpers.cs
+++ b/TimVer/Helpers/WindowsInfoHelpers.cs
@@ -47,7 +47,7 @@ internal static class WindowsInfoHelpers
             {GetStringResource("WindowsInfo_TempFolder"), info.TempFolder},
             {GetStringResource("WindowsInfo_DotNetVersion"), info.DotNetVersion},
         };
-        if (UserSettings.Setting!.ShowUser)
+        if (UserSettings.Setting.ShowUser)
         {
             windowsInfo.Add(GetStringResource("WindowsInfo_RegisteredUser"), info.RegisteredUser);
             windowsInfo.Add(GetStringResource("WindowsInfo_RegisteredOrg"), info.RegisteredOrg);

--- a/TimVer/ViewModels/AboutViewModel.cs
+++ b/TimVer/ViewModels/AboutViewModel.cs
@@ -21,11 +21,11 @@ internal sealed partial class AboutViewModel
     /// </summary>
     private static async Task<bool> CheckForNewReleaseOnLoadAsync()
     {
-        if (!UserSettings.Setting!.AutoCheckForUpdates)
+        if (!UserSettings.Setting.AutoCheckForUpdates)
         {
             return true;
         }
-        if (TempSettings.Setting!.CheckedForNewRelease)
+        if (TempSettings.Setting.CheckedForNewRelease)
         {
             return true;
         }

--- a/TimVer/ViewModels/DriveInfoViewModel.cs
+++ b/TimVer/ViewModels/DriveInfoViewModel.cs
@@ -42,7 +42,7 @@ internal sealed partial class DriveInfoViewModel : ObservableObject
 
     #region Refresh drives command
     /// <summary>
-    /// Relay command for freshing drives collections
+    /// Relay command for refreshing drives collections
     /// </summary>
     [RelayCommand]
     private static void RefreshDrives()
@@ -50,7 +50,7 @@ internal sealed partial class DriveInfoViewModel : ObservableObject
         LogicalDrivesList.Clear();
         DrivesPage.Instance!.LDrivesDataGrid.ItemsSource = LogicalDrivesList;
 
-        if (UserSettings.Setting!.GetPhysicalDrives)
+        if (UserSettings.Setting.GetPhysicalDrives)
         {
             PhysicalDrivesList.Clear();
             DrivesPage.Instance.PDisksDataGrid.ItemsSource = PhysicalDrivesList;

--- a/TimVer/ViewModels/NavigationViewModel.cs
+++ b/TimVer/ViewModels/NavigationViewModel.cs
@@ -9,7 +9,7 @@ internal sealed partial class NavigationViewModel : ObservableObject
     {
         if (CurrentViewModel == null)
         {
-            NavigateToPage(UserSettings.Setting!.InitialPage);
+            NavigateToPage(UserSettings.Setting.InitialPage);
         }
     }
     #endregion Constructor
@@ -322,7 +322,7 @@ internal sealed partial class NavigationViewModel : ObservableObject
     // Hopefully the name of each method is self-explanatory.
     private static void CycleColor()
     {
-        if (UserSettings.Setting!.PrimaryColor >= AccentColor.White)
+        if (UserSettings.Setting.PrimaryColor >= AccentColor.White)
         {
             UserSettings.Setting.PrimaryColor = AccentColor.Red;
         }
@@ -335,19 +335,19 @@ internal sealed partial class NavigationViewModel : ObservableObject
 
     private static void CycleRowSpacing()
     {
-        if (UserSettings.Setting?.RowSpacing >= Spacing.Wide)
+        if (UserSettings.Setting.RowSpacing >= Spacing.Wide)
         {
             UserSettings.Setting.RowSpacing = Spacing.Compact;
         }
         else
         {
-            UserSettings.Setting!.RowSpacing++;
+            UserSettings.Setting.RowSpacing++;
         }
     }
 
     private static void CycleTheme()
     {
-        UserSettings.Setting!.UITheme = UserSettings.Setting.UITheme switch
+        UserSettings.Setting.UITheme = UserSettings.Setting.UITheme switch
         {
             ThemeType.Light => ThemeType.LightGray,
             ThemeType.LightGray => ThemeType.Dark,
@@ -370,15 +370,15 @@ internal sealed partial class NavigationViewModel : ObservableObject
         {
             case "size":
                 composite = MsgTextUISizeSet;
-                messageVar = EnumHelpers.GetEnumDescription(UserSettings.Setting!.UISize);
+                messageVar = EnumHelpers.GetEnumDescription(UserSettings.Setting.UISize);
                 break;
             case "theme":
                 composite = MsgTextUIThemeSet;
-                messageVar = EnumHelpers.GetEnumDescription(UserSettings.Setting!.UITheme);
+                messageVar = EnumHelpers.GetEnumDescription(UserSettings.Setting.UITheme);
                 break;
             case "color":
                 composite = MsgTextUIColorSet;
-                messageVar = EnumHelpers.GetEnumDescription(UserSettings.Setting!.PrimaryColor);
+                messageVar = EnumHelpers.GetEnumDescription(UserSettings.Setting.PrimaryColor);
                 break;
         }
 

--- a/TimVer/Views/DrivesPage.xaml.cs
+++ b/TimVer/Views/DrivesPage.xaml.cs
@@ -9,7 +9,7 @@ public partial class DrivesPage : UserControl
     {
         InitializeComponent();
         Instance = this;
-        TabControl1.SelectedIndex = TempSettings.Setting!.DriveSelectedTab;
+        TabControl1.SelectedIndex = TempSettings.Setting.DriveSelectedTab;
     }
 
     #region Set active tab
@@ -17,7 +17,7 @@ public partial class DrivesPage : UserControl
     {
         if (TabControl1.SelectedIndex != -1)
         {
-            TempSettings.Setting!.DriveSelectedTab = TabControl1.SelectedIndex;
+            TempSettings.Setting.DriveSelectedTab = TabControl1.SelectedIndex;
         }
     }
     #endregion Set active tab
@@ -25,7 +25,7 @@ public partial class DrivesPage : UserControl
     #region Grid splitter drag completed event
     private void DetailsSplitter_DragCompleted(object sender, System.Windows.Controls.Primitives.DragCompletedEventArgs e)
     {
-        UserSettings.Setting!.DetailsHeight = Math.Floor(DetailsRow.Height.Value);
+        UserSettings.Setting.DetailsHeight = Math.Floor(DetailsRow.Height.Value);
     }
     #endregion Grid splitter drag completed event
 }


### PR DESCRIPTION
Remove nullable Setting refs; enforce non-null access

- Refactored codebase to eliminate all null-forgiving operators and nullable references to `UserSettings.Setting` and `TempSettings.Setting`.
- These properties are now non-nullable and throw exceptions if accessed before initialization, improving type safety and removing the need for repetitive null checks.
- Updated `ConfigManager<T>`.Setting to enforce non-null assignment and access.
- All usages of Setting throughout helpers, view models, and UI code-behind were updated to match the new contract.