### PR TITLE
Move translators

### DIFF
--- a/TimVer/Configuration/TempSettings.cs
+++ b/TimVer/Configuration/TempSettings.cs
@@ -12,16 +12,19 @@ internal sealed partial class TempSettings : ConfigManager<TempSettings>
     private static bool _appExpanderOpen;
 
     [ObservableProperty]
+    private static bool _backupExpanderOpen;
+
+    [ObservableProperty]
+    private static bool _checkedForNewRelease;
+
+    [ObservableProperty]
     private static bool _driveExpanderOpen;
 
     [ObservableProperty]
-    private static bool _logicalExpanderOpen;
-
-    [ObservableProperty]
-    private static bool _physicalExpanderOpen;
-
-    [ObservableProperty]
     private static int _driveSelectedTab;
+
+    [ObservableProperty]
+    private static string _gitHubRelease = string.Empty;
 
     [ObservableProperty]
     private bool _historyOnBoot = RegistryHelpers.RegRunEntry("TimVer");
@@ -30,20 +33,20 @@ internal sealed partial class TempSettings : ConfigManager<TempSettings>
     private static bool _langExpanderOpen;
 
     [ObservableProperty]
-    private static bool _uIExpanderOpen;
-
-    [ObservableProperty]
-    private static bool _runAccessPermitted;
-
-    [ObservableProperty]
-    private static bool _backupExpanderOpen;
-
-    [ObservableProperty]
-    private static bool _checkedForNewRelease;
+    private static bool _logicalExpanderOpen;
 
     [ObservableProperty]
     private static bool _newReleaseAvailable;
 
     [ObservableProperty]
-    private static string _gitHubRelease = string.Empty;
+    private static bool _physicalExpanderOpen;
+
+    [ObservableProperty]
+    private static bool _runAccessPermitted;
+
+    [ObservableProperty]
+    private static bool _translateExpanderOpen;
+
+    [ObservableProperty]
+    private static bool _uIExpanderOpen;
 }

--- a/TimVer/Styles/DataGridStyles.xaml
+++ b/TimVer/Styles/DataGridStyles.xaml
@@ -71,4 +71,13 @@
     </Style>
     <!--#endregion-->
 
+    <!--#region Right align cell text-->
+    <Style TargetType="DataGridCell"
+           x:Key="AlignCellRight"
+           BasedOn="{StaticResource {x:Type DataGridCell}}">
+        <Setter Property="Focusable" Value="False" />
+        <Setter Property="HorizontalAlignment" Value="Right" />
+    </Style>
+    <!--#endregion-->
+
 </ResourceDictionary>

--- a/TimVer/Views/AboutPage.xaml
+++ b/TimVer/Views/AboutPage.xaml
@@ -224,54 +224,67 @@
                            Background="{DynamicResource MaterialDesign.Brush.TextBox.HoverBackground}" />
                 <!--#endregion-->
 
-                <!--#region Translations-->
-                <Grid Grid.Row="11" Grid.Column="0">
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="26" />
-                        <RowDefinition Height="26" />
-                        <RowDefinition Height="*" />
-                    </Grid.RowDefinitions>
-                    <TextBlock Grid.Row="0"
-                               HorizontalAlignment="Left"
-                               FontWeight="SemiBold"
-                               Text="{DynamicResource About_Translations}" />
+                <!--#region Translations expander-->
+                <Expander Grid.Row="12" Grid.Column="0"
+                          Grid.ColumnSpan="3"
+                          Margin="0,10,0,0"
+                          materialDesign:ExpanderAssist.ExpanderButtonPosition="Start"
+                          materialDesign:ExpanderAssist.HorizontalHeaderPadding="5,10"
+                          IsExpanded="{Binding TranslateExpanderOpen,
+                                               Source={x:Static config:TempSettings.Setting}}">
+                    <Expander.Header>
+                        <Grid>
+                            <TextBlock Margin="10,0"
+                                       FontWeight="SemiBold"
+                                       Text="{DynamicResource About_Translations}"
+                                       TextWrapping="Wrap" />
+                        </Grid>
+                    </Expander.Header>
+                    <Grid Margin="40,0,0,0">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="auto" />
+                            <RowDefinition Height="20" />
+                            <RowDefinition Height="auto" />
+                            <RowDefinition Height="20" />
+                        </Grid.RowDefinitions>
 
-                    <TextBlock Grid.Row="1">
-                        <Hyperlink Command="{Binding GoToGitHubCommand}"
-                                   CommandParameter="https://github.com/Timthreetwelve/TimVer/wiki/Contribute-a-Translation"
-                                   Foreground="{DynamicResource MaterialDesign.Brush.Foreground}"
-                                   ToolTip="{DynamicResource About_ContributeToolTip}"
-                                   ToolTipService.Placement="Top">
-                            <TextBlock Text="{DynamicResource About_Contribute}" />
-                        </Hyperlink>
-                    </TextBlock>
-                </Grid>
+                        <DataGrid MinWidth="350"
+                                  HorizontalAlignment="Left"
+                                  d:ItemsSource="{d:SampleData ItemCount=4}"
+                                  materialDesign:DataGridAssist.CellPadding="15,5,15,5"
+                                  materialDesign:DataGridAssist.SelectedCellBorderBrush="Transparent"
+                                  AutoGenerateColumns="False"
+                                  Background="{DynamicResource MaterialDesign.Brush.Card.Background}"
+                                  BorderThickness="2"
+                                  HeadersVisibility="None"
+                                  IsReadOnly="True"
+                                  ItemsSource="{Binding AnnotatedLanguageList,
+                                                        Mode=OneWay}">
+                            <DataGrid.Columns>
+                                <DataGridTextColumn Binding="{Binding LanguageNative}"
+                                                    MinWidth="130" />
+                                <DataGridTextColumn Binding="{Binding LanguageCode}"
+                                                    MinWidth="60" />
+                                <DataGridTextColumn Binding="{Binding Contributor}"
+                                                    MinWidth="200" />
+                                <DataGridTextColumn Binding="{Binding Note}"
+                                                    MinWidth="90"
+                                                    CellStyle="{StaticResource AlignCellRight}" />
+                            </DataGrid.Columns>
+                        </DataGrid>
 
-                <DataGrid Grid.Row="11" Grid.Column="2"
-                          HorizontalAlignment="Left"
-                          materialDesign:DataGridAssist.CellPadding="{Binding RowSpacing,
-                                                                              Source={x:Static config:UserSettings.Setting},
-                                                                              Converter={StaticResource Spacing}}"
-                          AutoGenerateColumns="False"
-                          Background="{DynamicResource MaterialDesign.Brush.Card.Background}"
-                          BorderThickness="1"
-                          CellStyle="{StaticResource DisplayOnly}"
-                          HeadersVisibility="None"
-                          IsReadOnly="True"
-                          ItemsSource="{Binding AnnotatedLanguageList,
-                                                Mode=OneWay}">
-                    <DataGrid.Columns>
-                        <DataGridTextColumn Binding="{Binding LanguageNative}"
-                                            MinWidth="110" />
-                        <DataGridTextColumn Binding="{Binding LanguageCode}"
-                                            MinWidth="90" />
-                        <DataGridTextColumn Binding="{Binding Contributor}"
-                                            MinWidth="185" />
-                        <DataGridTextColumn Binding="{Binding Note}"
-                                            MinWidth="90"
-                                            ElementStyle="{StaticResource AlignRight}" />
-                    </DataGrid.Columns>
-                </DataGrid>
+                        <TextBlock Grid.Row="2">
+                            <Hyperlink Command="{Binding GoToGitHubCommand}"
+                                       CommandParameter="https://github.com/Timthreetwelve/GetMyIP/wiki/Contribute-a-Translation"
+                                       Foreground="{DynamicResource MaterialDesign.Brush.Foreground}"
+                                       ToolTip="{DynamicResource About_ContributeToolTip}"
+                                       ToolTipService.Placement="Top">
+                                <InlineUIContainer>
+                                    <TextBlock Text="{DynamicResource About_Contribute}" />
+                                </InlineUIContainer>
+                            </Hyperlink></TextBlock>
+                    </Grid>
+                </Expander>
                 <!--#endregion-->
             </Grid>
         </ScrollViewer>


### PR DESCRIPTION
Refactor Translations section with Expander control

- Replace Grid/DataGrid layout in AboutPage.xaml with a MaterialDesign Expander bound to new property in TempSettings.
- Nest DataGrid and Contribute link inside Expander for better UI organization.
- Added new DataGrid cell style.
- Sorted properties in TempSettings.