### PR TITLE
Improve design-time support for Setting property

### DIFF
--- a/TimVer/Configuration/ConfigManager.cs
+++ b/TimVer/Configuration/ConfigManager.cs
@@ -8,9 +8,27 @@ namespace TimVer.Configuration;
 /// <typeparam name="T">Class name of user settings</typeparam>
 public abstract class ConfigManager<T> where T : ConfigManager<T>, new()
 {
+    private static readonly bool _isDesignMode =
+        DesignerProperties.GetIsInDesignMode(new DependencyObject());
+
     public static T Setting
     {
-        get => field ?? throw new InvalidOperationException($"{typeof(T).Name}.Setting is not initialized.");
+        get
+        {
+            if (field is not null)
+            {
+                return field;
+            }
+
+            // If in design mode, create a new instance of T to avoid issues in the XAML designer.
+            if (_isDesignMode)
+            {
+                field = new T();
+                return field;
+            }
+
+            throw new InvalidOperationException($"ConfigManager: {typeof(T).Name}.Setting is not initialized.");
+        }
 
         set => field = value ?? throw new ArgumentNullException(nameof(value));
     }


### PR DESCRIPTION
- Add private static _isDesignMode field to detect XAML designer mode.
- Update Setting property getter:
  - Return field if initialized.
  - If in design mode, instantiate new T to avoid exceptions.
  - Otherwise, throw InvalidOperationException if not initialized.
- Prevents errors when accessing Setting in the designer, improving design-time experience.

No related issues or pull requests.