### PR TITLE
Enhance code robustness and maintainability by standardizing string and null checks.

### DIFF
--- a/TimVer/Helpers/HistoryHelpers.cs
+++ b/TimVer/Helpers/HistoryHelpers.cs
@@ -21,7 +21,7 @@ internal static class HistoryHelpers
         {
             string json = File.ReadAllText(DefaultHistoryFile());
             HistoryViewModel.HistoryList = JsonSerializer.Deserialize<List<History>>(json)!;
-            int count = HistoryViewModel.HistoryList!.Count;
+            int count = HistoryViewModel.HistoryList.Count;
             string entry = count == 1 ? "entry" : "entries";
             _log.Debug($"History file has {count} {entry}");
         }

--- a/TimVer/Helpers/PathHelpers.cs
+++ b/TimVer/Helpers/PathHelpers.cs
@@ -56,7 +56,7 @@ internal static class PathHelpers
         {
             throw new ArgumentException("Filename cannot be null, empty, or contain invalid characters.", nameof(filename));
         }
-        if (Path.GetExtension(filename) == string.Empty)
+        if (Path.GetExtension(filename)?.Length == 0)
         {
             throw new ArgumentException("Filename must have an extension.", nameof(filename));
         }

--- a/TimVer/Helpers/TextFileViewer.cs
+++ b/TimVer/Helpers/TextFileViewer.cs
@@ -31,10 +31,10 @@ internal static class TextFileViewer
             int ERROR_NO_ASSOCIATION = 1155;
             if (ex.NativeErrorCode == ERROR_NO_ASSOCIATION)
             {
-                string notepadPath = PathHelpers.FindOnPath("notepad.exe", false);
+                string notepadPath = PathHelpers.FindOnPath("notepad.exe");
                 if (string.IsNullOrEmpty(notepadPath))
                 {
-                    _log.Error($"Unable to find notepad.exe in PATH");
+                    _log.Error("Unable to find notepad.exe in PATH");
                     string msg = string.Format(CultureInfo.InvariantCulture, MsgTextErrorOpeningFile, textFile);
                     _ = MessageBox.Show($"{msg}\n\nUnable to find notepad.exe in PATH",
                                         GetStringResource("MsgText_ErrorCaption"),

--- a/TimVer/Helpers/TextFileViewer.cs
+++ b/TimVer/Helpers/TextFileViewer.cs
@@ -28,7 +28,7 @@ internal static class TextFileViewer
         }
         catch (Win32Exception ex)
         {
-            int ERROR_NO_ASSOCIATION = 1155;
+            const int ERROR_NO_ASSOCIATION = 1155;
             if (ex.NativeErrorCode == ERROR_NO_ASSOCIATION)
             {
                 string notepadPath = PathHelpers.FindOnPath("notepad.exe");

--- a/TimVer/ViewModels/NavigationViewModel.cs
+++ b/TimVer/ViewModels/NavigationViewModel.cs
@@ -171,7 +171,7 @@ internal sealed partial class NavigationViewModel : ObservableObject
     private static void OpenAppFolder()
     {
         string fileName = PathHelpers.FindOnPath("Explorer.exe");
-        if (fileName == string.Empty)
+        if (fileName?.Length == 0)
         {
             _log.Error("Error trying to open application folder: Explorer.exe not found");
             string msg = $"{GetStringResource("MsgText_Error_FileExplorer")}" +

--- a/TimVer/ViewModels/SettingsViewModel.cs
+++ b/TimVer/ViewModels/SettingsViewModel.cs
@@ -10,7 +10,7 @@ internal sealed partial class SettingsViewModel : ObservableObject
 
     #region Properties
     public static ReadOnlyCollection<FontFamily>? FontList { get; private set; }
-    public IEnumerable<ThemeType> ThemeTypes { get; private set; }
+    public IEnumerable<ThemeType> ThemeTypes { get; }
 
     public IEnumerable<ThemeType> SystemThemeTypes { get; private set; }
     #endregion Properties

--- a/TimVer/Views/AboutPage.xaml
+++ b/TimVer/Views/AboutPage.xaml
@@ -5,7 +5,6 @@
              xmlns:convert="clr-namespace:TimVer.Converters"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:helpers="clr-namespace:TimVer.Helpers"
-             xmlns:local="clr-namespace:TimVer"
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:viewmodels="clr-namespace:TimVer.ViewModels"
@@ -16,7 +15,6 @@
 
     <!--#region Resources-->
     <UserControl.Resources>
-        <convert:SpacingConverter x:Key="Spacing" />
         <convert:InvertibleBooleanToVisibilityConverter x:Key="InvertibleVisibilityConverter" />
     </UserControl.Resources>
     <!--#endregion-->
@@ -225,7 +223,7 @@
                 <!--#endregion-->
 
                 <!--#region Translations expander-->
-                <Expander Grid.Row="12" Grid.Column="0"
+                <Expander Grid.Row="11" Grid.Column="0"
                           Grid.ColumnSpan="3"
                           Margin="0,10,0,0"
                           materialDesign:ExpanderAssist.ExpanderButtonPosition="Start"


### PR DESCRIPTION


- Refactored null and empty string checks for improved safety and clarity:
  - Removed unnecessary null-forgiving operator from `HistoryHelpers` when accessing `HistoryList.Count`.
  - Updated `PathHelpers` to use `.Length == 0` instead of `Path.GetExtension(filename) == string.Empty`.
  - Changed `ERROR_NO_ASSOCIATION` in `TextFileViewer` to a `const int` for consistency.
  - Replaced `fileName == string.Empty` with `.Length == 0` in `NavigationViewModel` for better null safety.
- Removed unused xmlns:local and SpacingConverter from AboutPage.xaml
- Moved translations Expander from Grid.Row 12 to 11 for better layout
- Made ThemeTypes in SettingsViewModel.cs get-only for immutability
- Simplified PathHelpers.FindOnPath call in TextFileViewer.cs
- Updated log message formatting in TextFileViewer.cs for consistency

No related issues or pull requests.